### PR TITLE
Update integration name and requirements for Tesira TTP Control (#1)

### DIFF
--- a/custom_components/tesira_ttp/manifest.json
+++ b/custom_components/tesira_ttp/manifest.json
@@ -1,18 +1,20 @@
 {
-  "domain": "tesira_ttp",
-  "name": "Tesira TTP Volume (Telnet)",
-  "codeowners": [
-    "@bxthomas"
-  ],
-  "config_flow": true,
-  "documentation": "https://github.com/bxthomas/tesira_ttp",
-  "iot_class": "local_polling",
-  "issue_tracker": "https://github.com/bxthomas/tesira_ttp/issues",
-  "loggers": [
-    "custom_components.tesira_ttp"
-  ],
-  "requirements": [
-    "telnetlib3>=2.0.4"
-  ],
-  "version": "0.3.0"
+    "domain": "tesira_ttp",
+    "name": "Tesira TTP Control (Telnet)",
+    "version": "0.1.0",
+    "documentation": "https://github.com/Darnel-K/Tesira_TTP/wiki",
+    "issue_tracker": "https://github.com/Darnel-K/Tesira_TTP/issues",
+    "codeowners": [
+        "@Darnel-K"
+    ],
+    "requirements": [
+        "telnetlib3>=4.0.1"
+    ],
+    "dependencies": [],
+    "config_flow": true,
+    "integration_type": "hub",
+    "iot_class": "local_polling",
+    "loggers": [
+        "custom_components.tesira_ttp"
+    ]
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
-  "name": "Tesira TTP Volume (Telnet)",
-  "content_in_root": false,
-  "homeassistant": "2024.6.0"
+    "name": "Tesira TTP Control (Telnet)",
+    "content_in_root": false,
+    "homeassistant": "2026.3.2"
 }


### PR DESCRIPTION
* Update manifest metadata and telnetlib requirement

Update manifest.json for the forked integration: rename to Tesira TTP Control (Telnet), point documentation and issue tracker to the new repository, and change codeowner to @Darnel-K. Bump telnetlib3 requirement to >=4.0.1, add an empty dependencies array and set integration_type to hub. Version set to 0.1.0; config_flow, iot_class, and loggers preserved.

* Update hacs.json name and HA version

Rename integration from "Tesira TTP Volume (Telnet)" to "Tesira TTP Control (Telnet)" and bump the Home Assistant requirement from 2024.6.0 to 2026.3.2 in hacs.json to reflect the updated naming and compatibility.