### PR TITLE
Merge 'staging' into 'master'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,18 +1,6 @@
 # Python / Home Assistant build artifacts
 __pycache__/
 *.py[cod]
-*.so
-
-# Virtual envs / tooling
-.venv/
-.env/
-env/
 
 # OS / editor noise
-.DS_Store
-.idea/
 .vscode/
-
-# HA cache folders
-.storage/
-.pytest_cache/

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,661 @@
-MIT License
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
 
-Copyright (c) 2024 Brian Thomas
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+                            Preamble
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/README.md
+++ b/README.md
@@ -1,48 +1,56 @@
-# Tesira TTP Volume (Home Assistant)
 
-A Home Assistant custom integration that exposes **Biamp Tesira** level controls as `media_player` entities
-using the **Tesira Text Protocol (TTP)** over **Telnet (TCP/23)**.
+# Tesira TTP Control Integration for Home Assistant
 
-## Features
+![GitHub License](https://img.shields.io/github/license/Darnel-K/tesira_ttp)
+![HACS Badge](https://img.shields.io/badge/HACS-Custom-orange)
+![Platform](https://img.shields.io/badge/Home%20Assistant-Custom%20Integration-blue)
+![Protocol](https://img.shields.io/badge/Protocol-TTP%20(SSH)-lightgrey)
+![Protocol](https://img.shields.io/badge/Protocol-TTP%20(Telnet)-lightgrey)
 
-- UI setup via **Config Flow**
-- Add **multiple controls** (instance tag + channel) under one Tesira device via **Options**
-- `media_player` entity with:
-  - volume slider (maps 0–100% to your chosen dB range)
-  - volume up/down (relative step dB)
-  - mute (best-effort; depends on block)
+![GitHub Issues or Pull Requests](https://img.shields.io/github/issues/Darnel-K/tesira_ttp)
+![GitHub Issues or Pull Requests](https://img.shields.io/github/issues-pr/Darnel-K/tesira_ttp)
+![GitHub Release](https://img.shields.io/github/v/release/Darnel-K/tesira_ttp)
+![GitHub Downloads (all assets, all releases)](https://img.shields.io/github/downloads/Darnel-K/tesira_ttp/total)
+![GitHub release (latest by SemVer)](https://img.shields.io/github/downloads/Darnel-K/tesira_ttp/latest/total)
+
+This Home Assistant integration provides comprehensive control of **Biamp Tesira** systems using the **Tesira Text Protocol (TTP)** over **Telnet (TCP/23)** & **SSH (TCP/22)**. It exposes a **range of entity types**, enabling full interaction with Tesira DSP blocks directly from Home Assistant.
+
+> ⚠️ **WORK IN PROGRESS**
+> This project is currently under active development. Features may be incomplete or subject to change.
 
 ## Requirements
 
-- Tesira Text Protocol server enabled (Telnet / port 23)
-- Home Assistant with network access to the Tesira device
+- A Tesira DSP with **Telnet (TCP/23)** or **SSH (TCP/22)** enabled
+- Network access from Home Assistant to the Tesira DSP
 
-## Install
+## Installation
 
-### HACS (Custom repository)
+### HACS
 
-1. HACS → Integrations → ⋮ → **Custom repositories**
-2. Add `https://github.com/bxthomas/tesira_ttp` as **Integration**
-3. Install, then restart Home Assistant
+1. Open **HACS → Integrations**
+2. Select **⋮ → Custom repositories**
+3. Add `https://github.com/Darnel-K/tesira_ttp` as **Integration**
+4. Install and restart Home Assistant
 
 ### Manual
 
-Copy `custom_components/tesira_ttp/` to `/config/custom_components/tesira_ttp/` and restart HA.
+Copy:
 
-## Setup
+`custom_components/tesira_ttp/`
 
-Settings → Devices & services → Add integration → **Tesira TTP Volume (Telnet)**
+into:
 
-- ip / Port
-- Add your first control (name, instance tag, channel, min/max dB, step dB)
+`/config/custom_components/tesira_ttp/`
 
-To add more controls later:
+then restart Home Assistant.
 
-- Open the integration → **Configure** → Add / Edit / Remove controls
+## Configuration
 
-## Troubleshooting
+Navigate to: **Settings → Devices & services → Add integration → Tesira TTP Control (Telnet)**.
 
-Enable debug logs:
+## Debugging
+
+Enable debug logs in `configuration.yaml`:
 
 ```yaml
 logger:
@@ -51,14 +59,117 @@ logger:
     custom_components.tesira_ttp: debug
 ```
 
-## Development / CLI smoke test
+## Development / CLI Testing
 
-A small helper is included:
+An interactive CLI for testing Tesira TTP commands is included:
 
 `custom_components/tesira_ttp/tesira_cli.py`
 
-Run inside HA Core container on HAOS:
+It provides a cross‑platform interactive shell (powered by `prompt_toolkit`)
+for sending Tesira TTP commands, receiving real‑time publish‑token event updates,
+and testing SSH or Telnet connectivity directly from the terminal.
+
+---
+
+### CLI Arguments
+
+```text
+--host <IP>         (Required) Tesira device IP address
+--proto <proto>     Protocol: "ssh" (default) or "telnet"
+--user <username>   Username (default: "default")
+--password <pass>   Password (default: blank)
+--port <port>       Override TCP port (defaults: SSH=22, Telnet=23)
+```
+
+### Connection Examples from HA Core on HAOS
+
+Below are example commands demonstrating different connection scenarios.
+
+#### Connect with SSH (default protocol)
 
 ```bash
-ha core exec python3 /config/custom_components/tesira_ttp/tesira_cli.py --ip 192.168.40.84 --tag volume --get
+ha core exec python3 /config/custom_components/tesira_ttp/tesira_cli.py --host 10.xxx.xxx.xxx
 ```
+
+or
+
+```bash
+ha core exec python3 /config/custom_components/tesira_ttp/tesira_cli.py --host 10.xxx.xxx.xxx --proto ssh
+```
+
+You do not need to specify '`--proto ssh`' when connecting with SSH
+
+#### Connect with non-default port (SSH)
+
+```bash
+ha core exec python3 /config/custom_components/tesira_ttp/tesira_cli.py --host 10.xxx.xxx.xxx --port 2222
+```
+
+#### Connect with username and blank password (SSH)
+
+```bash
+ha core exec python3 /config/custom_components/tesira_ttp/tesira_cli.py --host 10.xxx.xxx.xxx --user admin
+```
+
+#### Connect with username and password (SSH)
+
+```bash
+ha core exec python3 /config/custom_components/tesira_ttp/tesira_cli.py --host 10.xxx.xxx.xxx --user admin --password MySecretPass
+```
+
+#### Connect with non-default port, username and password (SSH)
+
+```bash
+ha core exec python3 /config/custom_components/tesira_ttp/tesira_cli.py --host 10.xxx.xxx.xxx --port 2222 --user admin --password MySecretPass
+```
+
+#### Connect with Telnet
+
+```bash
+ha core exec python3 /config/custom_components/tesira_ttp/tesira_cli.py --host 10.xxx.xxx.xxx --proto telnet
+```
+
+#### Connect with non-default port (Telnet)
+
+```bash
+ha core exec python3 /config/custom_components/tesira_ttp/tesira_cli.py --host 10.xxx.xxx.xxx --proto telnet --port 2323
+```
+
+### Command Examples
+
+After launching, you can enter commands such as:
+
+```text
+DEVICE get deviceInfo
+Level1 get level 1
+Level1 subscribe level 1 test1 100
+unsubscribe test1
+```
+
+Special commands include:
+
+```text
+:json <command>   → run a command and parse Tesira-style JSON
+:ping             → measure round‑trip latency
+:exit             → quit the CLI
+```
+
+## Acknowledgements
+
+This project is a complete rewrite, but it began as a fork of the original Tesira TTP integration created by **bxthomas**. The original repository can be found here:
+
+**<https://github.com/bxthomas/tesira_ttp>**
+
+Their work provided the initial foundation that inspired this redesigned and fully expanded version.
+
+## License
+
+Released under the **GNU Affero General Public License v3.0 (AGPL‑3.0)**.
+
+## Status
+
+| Master | Staging | Develop |
+| ------ | ------- | ------- |
+| ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/Darnel-K/tesira_ttp/ci.yml?branch=master&label=HACS%20-%20Hassfest) | ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/Darnel-K/tesira_ttp/ci.yml?branch=staging&label=HACS%20-%20Hassfest) | ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/Darnel-K/tesira_ttp/ci.yml?branch=develop&label=HACS%20-%20Hassfest) |
+| ![GitHub manifest version (branch)](https://img.shields.io/github/manifest-json/v/Darnel-K/tesira_ttp/master?filename=custom_components%2Ftesira_ttp%2Fmanifest.json&label=Version) | ![GitHub manifest version (branch)](https://img.shields.io/github/manifest-json/v/Darnel-K/tesira_ttp/staging?filename=custom_components%2Ftesira_ttp%2Fmanifest.json&label=Version) | ![GitHub manifest version (branch)](https://img.shields.io/github/manifest-json/v/Darnel-K/tesira_ttp/develop?filename=custom_components%2Ftesira_ttp%2Fmanifest.json&label=Version) |
+| ![GitHub Release](https://img.shields.io/github/v/release/Darnel-K/tesira_ttp) |  | ![GitHub Release](https://img.shields.io/github/v/release/Darnel-K/tesira_ttp?include_prereleases) |

--- a/custom_components/tesira_ttp/__init__.py
+++ b/custom_components/tesira_ttp/__init__.py
@@ -1,3 +1,27 @@
+# #################################################################################################################### #
+# Filename: \custom_components\tesira_ttp\__init__.py                                                                  #
+# Repository: tesira_ttp                                                                                               #
+# Created Date: Sunday, March 22nd 2026, 10:04:37 PM                                                                   #
+# Last Modified: Saturday, March 28th 2026, 10:39:51 PM                                                                #
+# Original Author: Darnel Kumar                                                                                        #
+# Author Github: https://github.com/Darnel-K                                                                           #
+#                                                                                                                      #
+# License: GNU Affero General Public License v3.0 only - https://www.gnu.org/licenses/agpl.txt                         #
+# Copyright (c) 2026 Darnel Kumar                                                                                      #
+#                                                                                                                      #
+# This program is free software: you can redistribute it and/or modify                                                 #
+# it under the terms of the GNU Affero General Public License as published                                             #
+# by the Free Software Foundation, either version 3 of the License, or                                                 #
+# (at your option) any later version.                                                                                  #
+#                                                                                                                      #
+# This program is distributed in the hope that it will be useful,                                                      #
+# but WITHOUT ANY WARRANTY; without even the implied warranty of                                                       #
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                                                        #
+# GNU Affero General Public License for more details.                                                                  #
+#                                                                                                                      #
+# You should have received a copy of the GNU Affero General Public License                                             #
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.                                               #
+# #################################################################################################################### #
 from __future__ import annotations
 
 import logging
@@ -6,7 +30,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
 
-from .const import DOMAIN, PLATFORMS, CONF_IP, CONF_PORT
+from .const import DOMAIN, PLATFORMS, CONF_IP, CONF_PORT, CONF_PROTO, CONF_USER, CONF_PASS
 from .hub import TesiraHub
 
 _LOGGER = logging.getLogger(__name__)
@@ -26,14 +50,17 @@ async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> Non
     await hass.config_entries.async_reload(entry.entry_id)
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    ip = entry.data[CONF_IP]
+    host = entry.data[CONF_IP]
     port = entry.data[CONF_PORT]
+    proto = entry.data[CONF_PROTO]
+    user = entry.data.get(CONF_USER)
+    pwrd = entry.data.get(CONF_PASS)
 
     hubs: dict[str, TesiraHub] = hass.data[DOMAIN][DATA_HUBS]
-    hubkey = f"{ip}:{port}"
+    hubkey = f"{host}:{port}:{proto}"
     hub = hubs.get(hubkey)
     if hub is None:
-        hub = TesiraHub(ip, port)
+        hub = TesiraHub(host=host, port=port, proto=proto, username=user, password=pwrd, safe_mode=True)
         hubs[hubkey] = hub
         _LOGGER.debug("Created Tesira hub for %s", hubkey)
 
@@ -54,7 +81,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         if hubkey not in hass.data[DOMAIN][DATA_ENTRY_HUBKEY].values():
             hub = hubs.pop(hubkey, None)
             if hub:
-                await hub.close()
+                await hub.disconnect()
                 _LOGGER.debug("Closed Tesira hub for %s", hubkey)
 
     return unload_ok

--- a/custom_components/tesira_ttp/config_flow.py
+++ b/custom_components/tesira_ttp/config_flow.py
@@ -2,12 +2,25 @@
 # Filename: \custom_components\tesira_ttp\config_flow.py                                                               #
 # Repository: tesira_ttp                                                                                               #
 # Created Date: Thursday, March 19th 2026, 12:56:52 AM                                                                 #
-# Last Modified: Sunday, March 22nd 2026, 12:45:03 AM                                                                  #
+# Last Modified: Monday, March 30th 2026, 5:16:29 PM                                                                   #
 # Original Author: Darnel Kumar                                                                                        #
 # Author Github: https://github.com/Darnel-K                                                                           #
 #                                                                                                                      #
-# This code complies with: https://gist.github.com/Darnel-K/8badda0cabdabb15359350f7af911c90                           #
+# License: GNU Affero General Public License v3.0 only - https://www.gnu.org/licenses/agpl.txt                         #
 # Copyright (c) 2026 Darnel Kumar                                                                                      #
+#                                                                                                                      #
+# This program is free software: you can redistribute it and/or modify                                                 #
+# it under the terms of the GNU Affero General Public License as published                                             #
+# by the Free Software Foundation, either version 3 of the License, or                                                 #
+# (at your option) any later version.                                                                                  #
+#                                                                                                                      #
+# This program is distributed in the hope that it will be useful,                                                      #
+# but WITHOUT ANY WARRANTY; without even the implied warranty of                                                       #
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                                                        #
+# GNU Affero General Public License for more details.                                                                  #
+#                                                                                                                      #
+# You should have received a copy of the GNU Affero General Public License                                             #
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.                                               #
 # #################################################################################################################### #
 from __future__ import annotations
 
@@ -17,7 +30,7 @@ from typing import Any
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.core import HomeAssistant
+from homeassistant.helpers.selector import selector
 from homeassistant.data_entry_flow import FlowResult
 import homeassistant.helpers.config_validation as cv
 
@@ -25,6 +38,9 @@ from .const import (
     DOMAIN,
     CONF_IP,
     CONF_PORT,
+    CONF_PROTO,
+    CONF_USER,
+    CONF_PASS,
     CONF_CONTROLS,
     CONF_CONTROL_NAME,
     CONF_INSTANCE_TAG,
@@ -33,13 +49,16 @@ from .const import (
     CONF_MAX_DB,
     CONF_STEP_DB,
     DEFAULT_PORT,
+    DEFAULT_PROTO,
+    DEFAULT_USER,
+    DEFAULT_PASS,
     DEFAULT_CONTROL_NAME,
     DEFAULT_CHANNEL,
     DEFAULT_MIN_DB,
     DEFAULT_MAX_DB,
     DEFAULT_STEP_DB
 )
-from .tesira_client import TesiraTtpClient
+from .tesira_client import TesiraClient
 from .util import schema_with_defaults
 
 _LOGGER = logging.getLogger(__name__)
@@ -48,6 +67,16 @@ STEP_USER_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_IP): cv.string,
         vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+        vol.Required(CONF_PROTO, default=DEFAULT_PROTO): selector({
+            "select": {
+                "options": [
+                    {"value": "ssh", "label": "SSH"},
+                    {"value": "telnet", "label": "Telnet"}
+                ]
+            }
+        }),
+        vol.Optional(CONF_USER, default=DEFAULT_USER): cv.string,
+        vol.Optional(CONF_PASS, default=DEFAULT_PASS): cv.string
     }
 )
 
@@ -71,27 +100,44 @@ class TesiraTtpConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
 
         if user_input is not None:
-            ip = user_input[CONF_IP]
+            host = user_input[CONF_IP]
             port = user_input[CONF_PORT]
+            proto = user_input[CONF_PROTO]
+            user = user_input[CONF_USER]
+            pwrd = user_input[CONF_PASS]
 
-            # Use ip:port as unique key so a Tesira device is only configured once.
-            await self.async_set_unique_id(f"{ip}:{port}")
+            # Use host:port as unique key so a Tesira device is only configured once.
+            await self.async_set_unique_id(f"{host}:{port}:{proto}")
             self._abort_if_unique_id_configured()
 
             # Quick connectivity probe.
             try:
-                client = TesiraTtpClient(ip, port)
+                client = TesiraClient(host=host, port=port, proto=proto, username=user, password=pwrd)
                 await client.connect()
-                await client.close()
+                if client._conn is not None:
+                    await client.disconnect()
+                else:
+                    raise ConnectionError("Failed to establish connection")
+            except TesiraClient.InvalidCredentials as e:
+                _LOGGER.debug("Connectivity test failed: %s", e)
+                errors["base"] = "invalid_credentials"
+                return self.async_show_form(step_id="user", data_schema=STEP_USER_SCHEMA, errors=errors)
+            except TesiraClient.AuthenticationUnsupportedError as e:
+                _LOGGER.debug("Connectivity test failed: %s", e)
+                errors["base"] = "unsupported_authentication"
+                return self.async_show_form(step_id="user", data_schema=STEP_USER_SCHEMA, errors=errors)
             except Exception as e:
                 _LOGGER.debug("Connectivity test failed: %s", e)
                 errors["base"] = "cannot_connect"
                 return self.async_show_form(step_id="user", data_schema=STEP_USER_SCHEMA, errors=errors)
 
-            self.context["ip"] = ip
+            self.context["host"] = host
             self.context["port"] = port
-            title = f"Tesira {ip}:{port}"
-            return self.async_create_entry(title=title, data={CONF_IP: ip, CONF_PORT: port})
+            self.context["protocol"] = proto
+            self.context["username"] = user
+            self.context["password"] = pwrd
+            title = f"Tesira {host}:{port}"
+            return self.async_create_entry(title=title, data={CONF_IP: host, CONF_PORT: port, CONF_PROTO: proto, CONF_USER: user, CONF_PASS: pwrd})
 
         return self.async_show_form(step_id="user", data_schema=STEP_USER_SCHEMA, errors=errors)
 
@@ -102,28 +148,49 @@ class TesiraTtpConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         defaults = {
             CONF_IP: entry.data.get(CONF_IP),
             CONF_PORT: entry.data.get(CONF_PORT),
+            CONF_PROTO: entry.data.get(CONF_PROTO),
+            CONF_USER: entry.data.get(CONF_USER)
         }
         schema = schema_with_defaults(STEP_USER_SCHEMA, defaults)
 
         if user_input is not None:
-            ip = user_input[CONF_IP]
+            host = user_input[CONF_IP]
             port = user_input[CONF_PORT]
+            proto = user_input[CONF_PROTO]
+            user = user_input[CONF_USER]
+            pwrd = user_input[CONF_PASS]
 
-            await self.async_set_unique_id(f"{ip}:{port}")
-            self._abort_if_unique_id_configured()
+            new_unique_id = f"{host}:{port}:{proto}"
+            for config_entry in self.hass.config_entries.async_entries(DOMAIN):
+                if config_entry.unique_id == new_unique_id and config_entry.entry_id != entry.entry_id:
+                    return self.async_abort(reason="already_configured")
 
             try:
-                client = TesiraTtpClient(ip, port)
+                client = TesiraClient(host=host, port=port, proto=proto, username=user, password=pwrd)
                 await client.connect()
-                await client.close()
+                if client._conn is not None:
+                    await client.disconnect()
+                else:
+                    raise ConnectionError("Failed to establish connection")
+            except TesiraClient.InvalidCredentials as e:
+                _LOGGER.debug("Connectivity test failed: %s", e)
+                errors["base"] = "invalid_credentials"
+                return self.async_show_form(step_id="reconfigure", data_schema=schema, errors=errors)
+            except TesiraClient.AuthenticationUnsupportedError as e:
+                _LOGGER.debug("Connectivity test failed: %s", e)
+                errors["base"] = "unsupported_authentication"
+                return self.async_show_form(step_id="reconfigure", data_schema=schema, errors=errors)
             except Exception as e:
                 _LOGGER.debug("Connectivity test failed: %s", e)
                 errors["base"] = "cannot_connect"
                 return self.async_show_form(step_id="reconfigure", data_schema=schema, errors=errors)
 
-            self.context["ip"] = ip
+            self.context["host"] = host
             self.context["port"] = port
-            return self.async_update_reload_and_abort(self._get_reconfigure_entry(), data_updates=user_input)
+            self.context["protocol"] = proto
+            self.context["username"] = user
+            self.context["password"] = pwrd
+            return self.async_update_reload_and_abort(entry, data_updates=user_input)
 
         return self.async_show_form(step_id="reconfigure", data_schema=schema, errors=errors)
 

--- a/custom_components/tesira_ttp/const.py
+++ b/custom_components/tesira_ttp/const.py
@@ -1,3 +1,27 @@
+# #################################################################################################################### #
+# Filename: \custom_components\tesira_ttp\const.py                                                                     #
+# Repository: tesira_ttp                                                                                               #
+# Created Date: Thursday, March 19th 2026, 12:56:52 AM                                                                 #
+# Last Modified: Saturday, March 28th 2026, 10:28:26 PM                                                                #
+# Original Author: Darnel Kumar                                                                                        #
+# Author Github: https://github.com/Darnel-K                                                                           #
+#                                                                                                                      #
+# License: GNU Affero General Public License v3.0 only - https://www.gnu.org/licenses/agpl.txt                         #
+# Copyright (c) 2026 Darnel Kumar                                                                                      #
+#                                                                                                                      #
+# This program is free software: you can redistribute it and/or modify                                                 #
+# it under the terms of the GNU Affero General Public License as published                                             #
+# by the Free Software Foundation, either version 3 of the License, or                                                 #
+# (at your option) any later version.                                                                                  #
+#                                                                                                                      #
+# This program is distributed in the hope that it will be useful,                                                      #
+# but WITHOUT ANY WARRANTY; without even the implied warranty of                                                       #
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                                                        #
+# GNU Affero General Public License for more details.                                                                  #
+#                                                                                                                      #
+# You should have received a copy of the GNU Affero General Public License                                             #
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.                                               #
+# #################################################################################################################### #
 from __future__ import annotations
 
 from homeassistant.const import Platform
@@ -5,8 +29,11 @@ from homeassistant.const import Platform
 DOMAIN = "tesira_ttp"
 PLATFORMS: list[Platform] = [Platform.MEDIA_PLAYER]
 
-CONF_IP = "ip"
+CONF_IP = "host"
 CONF_PORT = "port"
+CONF_PROTO = "protocol"
+CONF_USER = "username"
+CONF_PASS = "password"
 
 # Controls live in options as a list of dicts
 CONF_CONTROLS = "controls"
@@ -18,7 +45,10 @@ CONF_MIN_DB = "min_db"
 CONF_MAX_DB = "max_db"
 CONF_STEP_DB = "step_db"
 
-DEFAULT_PORT = 23
+DEFAULT_PORT = 22
+DEFAULT_PROTO = "ssh"
+DEFAULT_USER = "default"
+DEFAULT_PASS = ""
 DEFAULT_CONTROL_NAME = "Tesira Volume"
 DEFAULT_CHANNEL = 1
 DEFAULT_MIN_DB = -100.0

--- a/custom_components/tesira_ttp/hub.py
+++ b/custom_components/tesira_ttp/hub.py
@@ -1,30 +1,95 @@
+# #################################################################################################################### #
+# Filename: \custom_components\tesira_ttp\hub.py                                                                       #
+# Repository: tesira_ttp                                                                                               #
+# Created Date: Thursday, March 19th 2026, 12:56:52 AM                                                                 #
+# Last Modified: Thursday, March 26th 2026, 12:25:05 AM                                                                #
+# Original Author: Darnel Kumar                                                                                        #
+# Author Github: https://github.com/Darnel-K                                                                           #
+#                                                                                                                      #
+# License: GNU Affero General Public License v3.0 only - https://www.gnu.org/licenses/agpl.txt                         #
+# Copyright (c) 2026 Darnel Kumar                                                                                      #
+#                                                                                                                      #
+# This program is free software: you can redistribute it and/or modify                                                 #
+# it under the terms of the GNU Affero General Public License as published                                             #
+# by the Free Software Foundation, either version 3 of the License, or                                                 #
+# (at your option) any later version.                                                                                  #
+#                                                                                                                      #
+# This program is distributed in the hope that it will be useful,                                                      #
+# but WITHOUT ANY WARRANTY; without even the implied warranty of                                                       #
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                                                        #
+# GNU Affero General Public License for more details.                                                                  #
+#                                                                                                                      #
+# You should have received a copy of the GNU Affero General Public License                                             #
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.                                               #
+# #################################################################################################################### #
 from __future__ import annotations
 
 import asyncio
 import logging
 
-from .tesira_client import TesiraTtpClient
+from .tesira_client import TesiraClient
 
 _LOGGER = logging.getLogger(__name__)
 
 class TesiraHub:
-    """Shared Telnet client per ip:port."""
+    """Shared SSH / Telnet client per host:port."""
 
-    def __init__(self, ip: str, port: int) -> None:
-        self.ip = ip
+    def __init__(self,
+        host: str,
+        username: str = "default",
+        password: str = "",
+        port: int = None,
+        proto: str = "ssh",
+        known_hosts=None,
+        heartbeat_interval: float = 10.0,
+        heartbeat_failure_threshold: int = 3,
+        heartbeat_jitter: float = 1.5,
+        safe_mode=False
+        ) -> None:
+        self.host = host
         self.port = port
-        self.client = TesiraTtpClient(ip, port)
+        self.username = username
+        self.password = password
+        self.proto = proto
+        self.known_hosts = known_hosts
+        self.heartbeat_interval = heartbeat_interval
+        self.heartbeat_failure_threshold = heartbeat_failure_threshold
+        self.heartbeat_jitter = heartbeat_jitter
+        self.safe_mode = safe_mode
+        self.client = TesiraClient(
+            host=host,
+            port=port,
+            username=username,
+            password=password,
+            proto=proto,
+            known_hosts=known_hosts,
+            heartbeat_interval=heartbeat_interval,
+            heartbeat_failure_threshold=heartbeat_failure_threshold,
+            heartbeat_jitter=heartbeat_jitter,
+            safe_mode=safe_mode
+        )
         self._lock = asyncio.Lock()
 
     @property
     def key(self) -> str:
-        return f"{self.ip}:{self.port}"
+        return f"{self.host}:{self.port}"
 
-    async def send_and_wait(self, line: str, timeout: float = 1.0) -> str:
-        # TesiraTtpClient already serializes requests, but we guard connect/close too.
+    async def json(self, cmd: str):
         async with self._lock:
-            return await self.client.send_and_wait(line, timeout=timeout)
+            return await self.client.json(cmd)
 
-    async def close(self) -> None:
+    async def command(self, cmd: str, timeout=5.0):
         async with self._lock:
-            await self.client.close()
+            return await self.client.command(cmd, timeout=timeout)
+
+    async def disconnect(self):
+        async with self._lock:
+            await self.client.disconnect()
+
+    async def subscribe(self, object_type, attribute, index, token, interval_ms, callback):
+        async with self._lock:
+            await self.client.subscribe(object_type, attribute, index, token, interval_ms, callback)
+
+    async def unsubscribe(self, token: str):
+        async with self._lock:
+            await self.client.unsubscribe(token)

--- a/custom_components/tesira_ttp/manifest.json
+++ b/custom_components/tesira_ttp/manifest.json
@@ -1,6 +1,6 @@
 {
     "domain": "tesira_ttp",
-    "name": "Tesira TTP Control (Telnet)",
+    "name": "Tesira Text Protocol (SSH & Telnet)",
     "codeowners": [
         "@Darnel-K"
     ],
@@ -15,7 +15,8 @@
     ],
     "requirements": [
         "telnetlib3>=4.0.1",
-        "asyncssh>=2.22.0"
+        "asyncssh>=2.22.0",
+        "prompt_toolkit>=3.0.52"
     ],
-    "version": "0.3.0"
+    "version": "0.8.0"
 }

--- a/custom_components/tesira_ttp/media_player.py
+++ b/custom_components/tesira_ttp/media_player.py
@@ -1,3 +1,27 @@
+# #################################################################################################################### #
+# Filename: \custom_components\tesira_ttp\media_player.py                                                              #
+# Repository: tesira_ttp                                                                                               #
+# Created Date: Thursday, March 19th 2026, 12:56:52 AM                                                                 #
+# Last Modified: Thursday, March 26th 2026, 11:30:26 PM                                                                #
+# Original Author: Darnel Kumar                                                                                        #
+# Author Github: https://github.com/Darnel-K                                                                           #
+#                                                                                                                      #
+# License: GNU Affero General Public License v3.0 only - https://www.gnu.org/licenses/agpl.txt                         #
+# Copyright (c) 2026 Darnel Kumar                                                                                      #
+#                                                                                                                      #
+# This program is free software: you can redistribute it and/or modify                                                 #
+# it under the terms of the GNU Affero General Public License as published                                             #
+# by the Free Software Foundation, either version 3 of the License, or                                                 #
+# (at your option) any later version.                                                                                  #
+#                                                                                                                      #
+# This program is distributed in the hope that it will be useful,                                                      #
+# but WITHOUT ANY WARRANTY; without even the implied warranty of                                                       #
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                                                        #
+# GNU Affero General Public License for more details.                                                                  #
+#                                                                                                                      #
+# You should have received a copy of the GNU Affero General Public License                                             #
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.                                               #
+# #################################################################################################################### #
 from __future__ import annotations
 
 import logging
@@ -20,6 +44,7 @@ from .const import (
     CONF_STEP_DB,
     CONF_IP,
     CONF_PORT,
+    CONF_PROTO,
     DEFAULT_CONTROL_NAME,
     DEFAULT_CHANNEL,
     DEFAULT_MIN_DB,
@@ -27,7 +52,6 @@ from .const import (
     DEFAULT_STEP_DB,
 )
 from .hub import TesiraHub
-from .tesira_client import parse_bool, parse_first_float
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -44,10 +68,11 @@ def level01_to_db(level01: float, min_db: float, max_db: float) -> float:
     return min_db + level01 * (max_db - min_db)
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities) -> None:
-    # Find shared hub by ip:port
-    ip = entry.data[CONF_IP]
+    # Find shared hub by host:port
+    host = entry.data[CONF_IP]
     port = entry.data[CONF_PORT]
-    hubkey = f"{ip}:{port}"
+    proto = entry.data[CONF_PROTO]
+    hubkey = f"{host}:{port}:{proto}"
     hub: TesiraHub = hass.data[DOMAIN]["hubs"][hubkey]
 
     controls: list[dict[str, Any]] = list(entry.options.get(CONF_CONTROLS, []))
@@ -60,7 +85,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
         min_db = float(c.get(CONF_MIN_DB, DEFAULT_MIN_DB))
         max_db = float(c.get(CONF_MAX_DB, DEFAULT_MAX_DB))
         step_db = float(c.get(CONF_STEP_DB, DEFAULT_STEP_DB))
-        entities.append(TesiraVolumeMediaPlayer(hub, ip, port, name, tag, ch, min_db, max_db, step_db))
+        entities.append(TesiraVolumeMediaPlayer(hub, host, port, name, tag, ch, min_db, max_db, step_db))
 
     async_add_entities(entities, update_before_add=True)
 
@@ -70,7 +95,7 @@ class TesiraVolumeMediaPlayer(MediaPlayerEntity):
     def __init__(
         self,
         hub: TesiraHub,
-        ip: str,
+        host: str,
         port: int,
         name: str,
         instance_tag: str,
@@ -80,7 +105,7 @@ class TesiraVolumeMediaPlayer(MediaPlayerEntity):
         step_db: float,
     ) -> None:
         self._hub = hub
-        self._ip = ip
+        self._host = host
         self._port = port
         self._tag = instance_tag
         self._ch = channel
@@ -89,7 +114,7 @@ class TesiraVolumeMediaPlayer(MediaPlayerEntity):
         self._step_db = step_db
 
         self._attr_name = name
-        self._attr_unique_id = f"tesira_ttp_{ip}_{port}_{self._tag}_{self._ch}".lower()
+        self._attr_unique_id = f"tesira_ttp_{host}_{port}_{self._tag}_{self._ch}".lower()
 
         self._attr_supported_features = (
             MediaPlayerEntityFeature.VOLUME_SET
@@ -115,8 +140,8 @@ class TesiraVolumeMediaPlayer(MediaPlayerEntity):
 
     async def async_update(self) -> None:
         try:
-            resp = await self._hub.send_and_wait(f"{self._tag} get level {self._ch}", timeout=2.0)
-            level = parse_first_float(resp)
+            resp = await self._hub.json(f"{self._tag} get level {self._ch}")
+            level = resp["value"]
             if level is None:
                 raise ValueError(f"Could not parse level from response: {resp!r}")
 
@@ -126,41 +151,32 @@ class TesiraVolumeMediaPlayer(MediaPlayerEntity):
 
             # mute is best-effort
             try:
-                resp_m = await self._hub.send_and_wait(f"{self._tag} get mute {self._ch}", timeout=1.0)
-                muted = parse_bool(resp_m)
+                resp_m = await self._hub.json(f"{self._tag} get mute {self._ch}")
+                muted = resp_m['value']
                 if muted is not None:
                     self._muted = muted
             except Exception:
                 pass
 
         except Exception as e:
-            _LOGGER.debug("Update failed for %s/%s ch %s: %s", self._ip, self._tag, self._ch, e)
+            _LOGGER.debug("Update failed for %s/%s ch %s: %s", self._host, self._tag, self._ch, e)
             self._attr_available = False
             self._attr_state = MediaPlayerState.UNAVAILABLE
 
     async def async_set_volume_level(self, volume: float) -> None:
         db = level01_to_db(volume, self._min_db, self._max_db)
-        await self._hub.send_and_wait(f"{self._tag} set level {self._ch} {db:.3f}", timeout=2.0)
+        await self._hub.json(f"{self._tag} set level {self._ch} {db:.3f}")
         self._level_db = db
 
     async def async_volume_up(self) -> None:
-        await self._hub.send_and_wait(
-            f"{self._tag} increment level {self._ch} {self._step_db:.3f}",
-            timeout=2.0,
-        )
+        await self._hub.json(f"{self._tag} increment level {self._ch} {self._step_db:.3f}")
 
     async def async_volume_down(self) -> None:
-        await self._hub.send_and_wait(
-            f"{self._tag} increment level {self._ch} {-self._step_db:.3f}",
-            timeout=2.0,
-        )
+        await self._hub.json(f"{self._tag} increment level {self._ch} {-self._step_db:.3f}")
 
     async def async_mute_volume(self, mute: bool) -> None:
-        resp = await self._hub.send_and_wait(
-            f"{self._tag} set mute {self._ch} {'true' if mute else 'false'}",
-            timeout=2.0,
-        )
-        if "-ERR" in resp:
-            _LOGGER.warning("Mute command returned error for %s: %s", self.entity_id, resp)
+        resp = await self._hub.json(f"{self._tag} set mute {self._ch} {'true' if mute else 'false'}")
+        if "error" in resp:
+            _LOGGER.warning("Mute command returned error for %s: %s", self.entity_id, resp['error'])
         else:
             self._muted = mute

--- a/custom_components/tesira_ttp/strings.json
+++ b/custom_components/tesira_ttp/strings.json
@@ -1,20 +1,28 @@
 {
+    "title": "Tesira Text Protocol (SSH & Telnet)",
+    "common": {},
     "config": {
         "step": {
             "user": {
                 "title": "Connect your Tesira DSP",
-                "description": "Enter the Tesira DSP IP address and port for the TTP Telnet server.",
+                "description": "Enter the Tesira DSP host, port, protocol & credentials for the Tesira Text Protocol server.",
                 "data": {
-                    "ip": "IP Address",
-                    "port": "Port"
+                    "host": "Host",
+                    "port": "Port",
+                    "protocol": "Protocol",
+                    "username": "Username (SSH only)",
+                    "password": "Password (SSH only)"
                 }
             },
             "reconfigure": {
                 "title": "Reconfigure Tesira DSP connection",
-                "description": "Enter the new Tesira DSP IP address and port for the TTP Telnet server.",
+                "description": "Enter the Tesira DSP host, port, protocol & credentials for the Tesira Text Protocol server.",
                 "data": {
-                    "ip": "IP Address",
-                    "port": "Port"
+                    "host": "Host",
+                    "port": "Port",
+                    "protocol": "Protocol",
+                    "username": "Username (SSH only)",
+                    "password": "Password (SSH only)"
                 }
             },
             "control": {
@@ -31,10 +39,13 @@
             }
         },
         "error": {
-            "cannot_connect": "Cannot connect to the Tesira device."
+            "cannot_connect": "Cannot connect to the Tesira device.",
+            "invalid_credentials": "Invalid credentials for SSH connection. Please check your username and password.",
+            "unsupported_authentication": "Authentication is not supported when using Telnet. Please switch to SSH or leave username as default and password blank."
         },
         "abort": {
-            "already_configured": "This Tesira device is already configured."
+            "already_configured": "This Tesira device is already configured.",
+            "reconfigure_successful": "Tesira DSP connection reconfigured successfully."
         }
     },
     "options": {

--- a/custom_components/tesira_ttp/tesira_cli.py
+++ b/custom_components/tesira_ttp/tesira_cli.py
@@ -1,83 +1,156 @@
+# #################################################################################################################### #
+# Filename: \custom_components\tesira_ttp\tesira_cli.py                                                                #
+# Repository: tesira_ttp                                                                                               #
+# Created Date: Thursday, March 19th 2026, 12:56:52 AM                                                                 #
+# Last Modified: Thursday, March 26th 2026, 12:26:02 AM                                                                #
+# Original Author: Darnel Kumar                                                                                        #
+# Author Github: https://github.com/Darnel-K                                                                           #
+#                                                                                                                      #
+# License: GNU Affero General Public License v3.0 only - https://www.gnu.org/licenses/agpl.txt                         #
+# Copyright (c) 2026 Darnel Kumar                                                                                      #
+#                                                                                                                      #
+# This program is free software: you can redistribute it and/or modify                                                 #
+# it under the terms of the GNU Affero General Public License as published                                             #
+# by the Free Software Foundation, either version 3 of the License, or                                                 #
+# (at your option) any later version.                                                                                  #
+#                                                                                                                      #
+# This program is distributed in the hope that it will be useful,                                                      #
+# but WITHOUT ANY WARRANTY; without even the implied warranty of                                                       #
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                                                        #
+# GNU Affero General Public License for more details.                                                                  #
+#                                                                                                                      #
+# You should have received a copy of the GNU Affero General Public License                                             #
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.                                               #
+# #################################################################################################################### #
 #!/usr/bin/env python3
-"""Console test utility for TesiraTtpClient (Telnet).
-
-Run on HAOS inside the Home Assistant Core container:
-
-  ha core exec python3 /config/custom_components/tesira_ttp/tesira_cli.py --ip 192.168.40.84 --tag volume --get
-  ha core exec python3 /config/custom_components/tesira_ttp/tesira_cli.py --ip 192.168.40.84 --tag volume --inc 1.0
-  ha core exec python3 /config/custom_components/tesira_ttp/tesira_cli.py --ip 192.168.40.84 --tag volume --set -20
-  ha core exec python3 /config/custom_components/tesira_ttp/tesira_cli.py --ip 192.168.40.84 --interactive
+"""
+Tesira Interactive CLI using prompt_toolkit (Windows/Linux/Mac Compatible)
 """
 
-import argparse
 import asyncio
+import argparse
+from prompt_toolkit import PromptSession
+from prompt_toolkit.patch_stdout import patch_stdout
 
-from tesira_client import TesiraTtpClient, parse_first_float
+from tesira_client import TesiraClient
 
-async def main() -> int:
-    ap = argparse.ArgumentParser()
-    ap.add_argument("--ip", required=True)
-    ap.add_argument("--port", type=int, default=23)
-    ap.add_argument("--tag", default="volume")
-    ap.add_argument("--ch", type=int, default=1)
 
-    ap.add_argument("--get", action="store_true")
-    ap.add_argument("--set", type=float)
-    ap.add_argument("--inc", type=float)
-    ap.add_argument("--raw", type=str)
-    ap.add_argument("--interactive", action="store_true")
+BANNER = r"""
+============================================================
+               TESIRA INTERACTIVE TERMINAL
+============================================================
+Type any Tesira TTP command, e.g.:
 
-    args = ap.parse_args()
+    DEVICE get deviceInfo
+    Level1 get level 1
+    LogicState1 get states
+    Level1 set level 1 -6.0
+    SUBSCRIBE Level1 level 1 test 200
+    unsubscribe test
 
-    c = TesiraTtpClient(args.ip, args.port)
+Special commands:
+    :exit       Quit CLI
+    :json CMD   Run TesiraClient.json(CMD)
+    :ping       Measure latency
+============================================================
+"""
 
-    async def send(line: str):
-        resp = await c.send_and_wait(line, timeout=2.0)
-        print(resp.strip())
-        return resp
 
-    if args.interactive:
-        await c.connect()
-        print("Connected. Type TTP commands; Ctrl-D to exit.")
-        try:
-            while True:
-                line = await asyncio.get_running_loop().run_in_executor(None, lambda: input("> "))
-                if not line.strip():
+async def subscription_printer(event: dict, session: PromptSession):
+    # Print event above the input line
+    print(f"[EVENT] {event}")
+
+    # Safely request a prompt redraw
+    app = session.app
+    if app is not None:
+        app.invalidate()
+
+
+async def interactive_shell(client: TesiraClient):
+    print(BANNER)
+
+    # Prompt toolkit session (handles async-safe input line)
+    session = PromptSession("TTP> ")
+
+    # Assign global callback (wrapped so we can access session)
+    async def printer(event):
+        await subscription_printer(event, session)
+
+    client._event_callback = printer
+
+    # Keep terminal safe while async printing occurs
+    with patch_stdout():
+        while True:
+            try:
+                cmd = await session.prompt_async()
+            except (EOFError, KeyboardInterrupt):
+                print("Exiting.")
+                break
+
+            cmd = cmd.strip()
+            if not cmd:
+                continue
+
+            if cmd.lower() in (":exit", "exit", "quit"):
+                print("Disconnecting...")
+                await client.disconnect()
+                print("Bye!")
+                return
+
+            if cmd.startswith(":json"):
+                real_cmd = cmd[6:].strip()
+                if not real_cmd:
+                    print("Usage: :json <TTP command>")
                     continue
-                await send(line)
-        except (EOFError, KeyboardInterrupt):
-            pass
-        await c.close()
-        return 0
 
-    if args.raw:
-        await send(args.raw)
-        await c.close()
-        return 0
+                try:
+                    result = await client.json(real_cmd)
+                    print(result)
+                except Exception as e:
+                    print("ERROR:", e)
+                continue
 
-    tag, ch = args.tag, args.ch
+            if cmd == ":ping":
+                try:
+                    ms = await client.ping()
+                    print(f"Ping: {ms:.2f} ms")
+                except Exception as e:
+                    print("Ping ERROR:", e)
+                continue
 
-    if args.get:
-        resp = await send(f"{tag} get level {ch}")
-        val = parse_first_float(resp)
-        if val is not None:
-            print(f"Parsed level: {val} dB")
-        await c.close()
-        return 0
+            # Normal TTP command
+            try:
+                result = await client.command(cmd)
+                print(result)
+            except Exception as e:
+                print("ERROR:", e)
 
-    if args.set is not None:
-        await send(f"{tag} set level {ch} {args.set:.3f}")
-        await c.close()
-        return 0
 
-    if args.inc is not None:
-        await send(f"{tag} increment level {ch} {args.inc:.3f}")
-        await c.close()
-        return 0
+async def main():
+    parser = argparse.ArgumentParser(description="Tesira Interactive CLI")
+    parser.add_argument("--host", required=True, help="Tesira Host")
+    parser.add_argument("--proto", default="ssh", choices=["ssh", "telnet"], help="Protocol")
+    parser.add_argument("--user", default="default", help="Username")
+    parser.add_argument("--password", default="", help="Password")
+    parser.add_argument("--port", type=int, help="Port override", default=None)
+    args = parser.parse_args()
 
-    ap.print_help()
-    await c.close()
-    return 1
+    print(f"Connecting to {args.host} via {args.proto.upper()} ...")
+
+    client = TesiraClient(
+        host=args.host,
+        username=args.user,
+        password=args.password,
+        port=args.port,
+        proto=args.proto,
+    )
+
+    await client.connect()
+    await interactive_shell(client)
+
 
 if __name__ == "__main__":
-    raise SystemExit(asyncio.run(main()))
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        print("\nExiting.")

--- a/custom_components/tesira_ttp/tesira_client.py
+++ b/custom_components/tesira_ttp/tesira_client.py
@@ -2,12 +2,25 @@
 # Filename: \custom_components\tesira_ttp\tesira_client.py                                                             #
 # Repository: tesira_ttp                                                                                               #
 # Created Date: Thursday, March 19th 2026, 12:56:52 AM                                                                 #
-# Last Modified: Sunday, March 22nd 2026, 7:06:25 PM                                                                   #
+# Last Modified: Monday, March 30th 2026, 3:26:17 PM                                                                   #
 # Original Author: Darnel Kumar                                                                                        #
 # Author Github: https://github.com/Darnel-K                                                                           #
 #                                                                                                                      #
-# This code complies with: https://gist.github.com/Darnel-K/8badda0cabdabb15359350f7af911c90                           #
+# License: GNU Affero General Public License v3.0 only - https://www.gnu.org/licenses/agpl.txt                         #
 # Copyright (c) 2026 Darnel Kumar                                                                                      #
+#                                                                                                                      #
+# This program is free software: you can redistribute it and/or modify                                                 #
+# it under the terms of the GNU Affero General Public License as published                                             #
+# by the Free Software Foundation, either version 3 of the License, or                                                 #
+# (at your option) any later version.                                                                                  #
+#                                                                                                                      #
+# This program is distributed in the hope that it will be useful,                                                      #
+# but WITHOUT ANY WARRANTY; without even the implied warranty of                                                       #
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                                                        #
+# GNU Affero General Public License for more details.                                                                  #
+#                                                                                                                      #
+# You should have received a copy of the GNU Affero General Public License                                             #
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.                                               #
 # #################################################################################################################### #
 from __future__ import annotations
 
@@ -19,61 +32,9 @@ import random
 import re
 import time
 import logging
-
-# For backward compatibility, this module still contains the old TesiraTtpClient class,
-# but it is now a wrapper around the new TesiraClient which supports both SSH and Telnet. The new TesiraClient is more robust and feature-rich, while TesiraTtpClient preserves the old API for existing code. New code should use TesiraClient directly for better performance and reliability.
-from typing import Optional
+import inspect
 
 _LOGGER = logging.getLogger(__name__)
-
-# =====================================================================
-# Legacy Parser Helper Functions (module-level for imports)
-# =====================================================================
-def parse_first_float(text: str) -> Optional[float]:
-    m = re.search(r'"value"\s*:\s*(-?\d+(?:\.\d+)?)', text)
-    if m:
-        try:
-            return float(m.group(1))
-        except Exception:
-            pass
-
-    m = re.search(r'(-?\d+(?:\.\d+)?)', text)
-    if m:
-        try:
-            return float(m.group(1))
-        except Exception:
-            pass
-
-    return None
-
-
-def parse_bool(text: str) -> Optional[bool]:
-    s = text.lower()
-    if "true" in s:
-        return True
-    if "false" in s:
-        return False
-    if re.search(r'\b1\b', s):
-        return True
-    if re.search(r'\b0\b', s):
-        return False
-    return None
-
-# =====================================================================
-# Exceptions
-# =====================================================================
-class TesiraError(Exception):
-    """Represents a Tesira TTP -ERR response."""
-    def __init__(self, message, raw=None, cmd=None):
-        super().__init__(message)
-        self.message = message
-        self.raw = raw
-        self.cmd = cmd
-
-
-class TesiraConnectionError(Exception):
-    pass
-
 
 # =====================================================================
 # Tesira Client (SSH + TELNET)
@@ -95,18 +56,18 @@ class TesiraClient:
         heartbeat_failure_threshold: int = 3,
         heartbeat_jitter: float = 1.5,
 
-        safe_mode=False,
+        safe_mode=False
     ):
         # -----------------------------------------------------------------
         # Protocol validation
         # -----------------------------------------------------------------
         proto = proto.lower().strip()
         if proto not in self.ALLOWED_PROTOCOLS:
-            raise ValueError(f"Unsupported protocol '{proto}'. Allowed: {self.ALLOWED_PROTOCOLS}")
+            raise self.ProtocolError(f"Unsupported protocol '{proto}'. Allowed: {self.ALLOWED_PROTOCOLS}")
 
         if proto == "telnet":
             if username != "default" or (password not in ("", None)):
-                raise ValueError("Telnet only supports user='default' with blank password.")
+                raise self.AuthenticationUnsupportedError("Telnet only supports user='default' with blank password.")
             if port is None:
                 port = 23
 
@@ -227,68 +188,77 @@ class TesiraClient:
     # =====================================================================
     # CONNECT (SSH + TELNET)
     # =====================================================================
-    async def connect(self, attempt=1):
+    async def connect(self, max_retries=5):
         if self._conn:
             return
 
-        backoff = min(1 * (2 ** (attempt - 1)), 20)
+        attempt = 1
 
-        try:
-            _LOGGER.debug("[NET] Connecting via %s to %s:%s",
-                          self.proto.upper(), self.host, self.port)
+        for attempt in range(attempt, max_retries + 1):
+            backoff = min(1 * (2 ** (attempt - 1)), 20)
 
-            # ---------------------------------------------------------
-            # SSH CONNECTION
-            # ---------------------------------------------------------
-            if self.proto == "ssh":
+            try:
+                _LOGGER.debug("[NET] Connecting via %s to %s:%s",
+                            self.proto.upper(), self.host, self.port)
 
-                self._conn = await asyncssh.connect(
-                    self.host,
-                    username=self.username,
-                    password=self.password,
-                    port=self.port,
-                    known_hosts=self.known_hosts,
-                )
+                # ---------------------------------------------------------
+                # SSH CONNECTION
+                # ---------------------------------------------------------
+                if self.proto == "ssh":
 
-                # Factory creates NEW session instance and stores it
-                def factory():
-                    sess = TesiraClient._SSHSession(self)
-                    self._session = sess
-                    return sess
+                    self._conn = await asyncssh.connect(
+                        self.host,
+                        username=self.username,
+                        password=self.password,
+                        port=self.port,
+                        known_hosts=self.known_hosts,
+                    )
 
-                self._chan, _ = await self._conn.create_session(factory, term_type="vt100")
-                self._chan.write("\r\n")
+                    # Factory creates NEW session instance and stores it
+                    def factory():
+                        sess = TesiraClient._SSHSession(self)
+                        self._session = sess
+                        return sess
 
-            # ---------------------------------------------------------
-            # TELNET CONNECTION
-            # ---------------------------------------------------------
-            else:
-                self._reader, self._writer = await telnetlib3.open_connection(
-                    self.host,
-                    self.port,
-                    shell=None
-                )
+                    self._chan, _ = await self._conn.create_session(factory, term_type="vt100")
+                    self._chan.write("\r\n")
 
-                self._session = TesiraClient._TelnetSession(self)
-                self._conn = True  # sentinel indicating connected
+                # ---------------------------------------------------------
+                # TELNET CONNECTION
+                # ---------------------------------------------------------
+                else:
+                    self._reader, self._writer = await telnetlib3.open_connection(
+                        self.host,
+                        self.port,
+                        shell=None
+                    )
 
-                # Background reader
-                self._telnet_reader_future = asyncio.create_task(self._telnet_reader_task())
+                    self._session = TesiraClient._TelnetSession(self)
+                    self._conn = True  # sentinel indicating connected
 
-                self._writer.write("\r\n")
+                    # Background reader
+                    self._telnet_reader_future = asyncio.create_task(self._telnet_reader_task())
 
-            _LOGGER.debug("[NET] Connected")
+                    self._writer.write("\r\n")
 
-            # Start heartbeat once
-            if self._heartbeat_task is None:
-                self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
+                _LOGGER.debug("[NET] Connected")
 
-            await self._resubscribe_all()
+                # Start heartbeat once
+                if self._heartbeat_task is None:
+                    self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
 
-        except Exception as e:
-            _LOGGER.error("[NET] Connect failed (%s), retrying in %s s", e, backoff)
-            await asyncio.sleep(backoff)
-            return await self.connect(attempt + 1)
+                await self._resubscribe_all()
+
+                break
+            except asyncssh.PermissionDenied as e:
+                _LOGGER.error("[NET] Invalid credentials: %s", e)
+                raise self.InvalidCredentials(f"Invalid credentials: {e}")
+            except Exception as e:
+                _LOGGER.error("[NET] Connection attempt (%s) failed (%s), retrying in %s s", attempt, e, backoff)
+                if attempt == max_retries:
+                    _LOGGER.error(f"[NET] Maximum connection attempts reached: {e}")
+                    raise ConnectionError(f"Maximum connection attempts reached: {e}")
+                await asyncio.sleep(backoff)
 
 
     # =====================================================================
@@ -348,7 +318,7 @@ class TesiraClient:
             try:
                 await asyncio.wait_for(self._session.complete.wait(), timeout)
             except asyncio.TimeoutError:
-                raise TesiraError("Timeout waiting for +OK or -ERR", raw=self._session.buffer, cmd=cmd)
+                raise self.TimeoutError("Timeout waiting for +OK or -ERR", raw=self._session.buffer, cmd=cmd)
 
             raw = self._session.buffer.strip()
             lines = [l.strip() for l in raw.splitlines()]
@@ -356,12 +326,12 @@ class TesiraClient:
             final = next((l for l in lines if l.startswith("+OK") or l.startswith("-ERR")), None)
 
             if not final:
-                raise TesiraError("No +OK/-ERR returned", raw=raw, cmd=cmd)
+                raise self.CommandError("No +OK/-ERR returned", raw=raw, cmd=cmd)
 
             if final.startswith("-ERR"):
                 if self.safe_mode:
                     return {"error": final, "raw": raw}
-                raise TesiraError(final, raw=raw, cmd=cmd)
+                raise self.CommandError(final, raw=raw, cmd=cmd)
 
             return final
 
@@ -393,7 +363,7 @@ class TesiraClient:
         try:
             return json.loads(payload)
         except Exception as e:
-            raise TesiraError(f"JSON parsing failed: {e}", raw=payload, cmd=cmd)
+            raise self.JSONParseError(f"JSON parsing failed: {e}", raw=payload, cmd=cmd)
 
 
     # =====================================================================
@@ -438,7 +408,7 @@ class TesiraClient:
     async def unsubscribe(self, token: str):
         try:
             await self.command(f"unsubscribe {token}")
-        except TesiraError:
+        except self.CommandError:
             await self.command(f"UNSUBSCRIBE {token}")
 
         self._subscriptions.pop(token, None)
@@ -474,17 +444,26 @@ class TesiraClient:
         if not token:
             return
 
+        # Subscription callback
         sub = self._subscriptions.get(token)
         if sub:
             cb = sub["callback"]
             try:
-                cb(data)
+                if inspect.iscoroutinefunction(cb):
+                    asyncio.create_task(cb(data))
+                else:
+                    cb(data)
             except Exception as e:
                 _LOGGER.error("[EVENT ERROR] %s", e)
 
+        # Global event callback
         if self._event_callback:
+            cb = self._event_callback
             try:
-                self._event_callback(data)
+                if inspect.iscoroutinefunction(cb):
+                    asyncio.create_task(cb(data))
+                else:
+                    cb(data)
             except Exception as e:
                 _LOGGER.error("[EVENT ERROR global] %s", e)
 
@@ -519,154 +498,36 @@ class TesiraClient:
     async def queue(self, cmd: str):
         return await self.command(cmd)
 
+    # =====================================================================
+    # Exceptions
+    # =====================================================================
+    class CommandError(Exception):
+        """Represents a Tesira TTP -ERR response."""
+        def __init__(self, message, raw=None, cmd=None):
+            super().__init__(message)
+            self.message = message
+            self.raw = raw
+            self.cmd = cmd
 
-_OK_RE = re.compile(r"\+OK", re.IGNORECASE)
-_ERR_RE = re.compile(r"-ERR", re.IGNORECASE)
+    class InvalidCredentials(Exception):
+        pass
 
-class TesiraTtpClient:
-    """
-    Full backwards‑compatible wrapper for the old TesiraTtpClient API.
-    Internally uses the new TesiraClient, but preserves:
-        - raw output rules
-        - CRLF behavior
-        - timeout behavior
-        - connect()
-        - close()
-        - send_and_wait()
-        - parse helpers
-    """
+    class ProtocolError(Exception):
+        pass
 
-    def __init__(self, ip: str, port: int = 23, proto: str = "telnet",
-                 user: str = "default", password: str = None):
+    class JSONParseError(Exception):
+        def __init__(self, message, raw=None, cmd=None):
+            super().__init__(message)
+            self.message = message
+            self.raw = raw
+            self.cmd = cmd
 
-        from .tesira_client import TesiraClient
+    class AuthenticationUnsupportedError(Exception):
+        pass
 
-        proto = proto.strip().lower()
-        if proto == "telnet":
-            _LOGGER.warning(
-                "Using Telnet protocol is not recommended. For more information, see https://support.biamp.com/Tesira/Control/Tesira_security_best_practices"
-            )
-            if user != "default" or password not in (None, ""):
-                raise NotImplementedError(
-                    "Telnet only supports user='default' + blank password."
-                )
-        elif proto != "ssh":
-            raise ValueError(f"Unsupported proto={proto!r}")
-
-        # Use new TesiraClient internally
-        self._client = TesiraClient(
-            host=ip,
-            username=user,
-            password=password or "",
-            port=port,
-            proto=proto,
-        )
-
-        self._lock = asyncio.Lock()
-        self._proto = proto
-        self._ip = ip
-        self._port = port
-
-    # ----------------------------------------------------------------------
-    @property
-    def is_connected(self) -> bool:
-        # old behavior: true if connection exists and not closing
-        return self._client._conn is not None
-
-    # ----------------------------------------------------------------------
-    async def connect(self) -> None:
-        """Old behavior: connect and drain banner."""
-        await self._client.connect()
-
-        # OLD CLIENT drained banner for 1 second.
-        # We emulate that for backwards compatibility.
-        await self._drain_for(1.0)
-
-        # OLD CLIENT nudged prompt readiness with CRLF
-        await self._send_raw("\r\n")
-        await asyncio.sleep(0.3)  # old timing
-
-    # ----------------------------------------------------------------------
-    async def close(self) -> None:
-        await self._client.disconnect()
-
-    # ----------------------------------------------------------------------
-    async def _send_raw(self, text: str) -> None:
-        """Send raw text to Tesira using underlying protocol."""
-        if self._proto == "ssh":
-            self._client._chan.write(text)
-        else:
-            self._client._writer.write(text)
-
-    # ----------------------------------------------------------------------
-    async def _read_raw(self, max_bytes=1024) -> str:
-        """
-        Read raw data FROM THE SESSION BUFFER instead of the TelnetReader.
-        This avoids telnetlib3 read conflicts.
-        """
-        if self._proto == "ssh":
-            # SSH safe to read directly:
-            try:
-                return await asyncio.wait_for(self._client._chan.read(max_bytes), timeout=0.2)
-            except:
-                return ""
-
-        # TELNET SAFE PATH:
-        # Pull from buffered data gathered by _telnet_reader_task
-        await asyncio.sleep(0.05)  # allow buffer to fill
-        buf = self._client._session.buffer
-        self._client._session.buffer = ""  # consume it
-        return buf
-
-
-    # ----------------------------------------------------------------------
-    async def _drain_for(self, seconds: float) -> str:
-        """Old behavior: read whatever arrives for N seconds."""
-        end = asyncio.get_running_loop().time() + seconds
-        buf = []
-        while asyncio.get_running_loop().time() < end:
-            chunk = await self._read_raw()
-            if chunk:
-                buf.append(chunk)
-        return "".join(buf)
-
-    # ----------------------------------------------------------------------
-    async def send_and_wait(self, line: str, timeout: float = 1.0) -> str:
-        """
-        EXACT old behavior:
-          - sends raw line
-          - reads raw text until +OK or -ERR
-          - returns the FULL raw blob, not the cleaned line.
-        """
-        async with self._lock:
-            await self.connect()
-
-            # normalize CRLF
-            line = line.rstrip("\r\n")
-            payload = line + "\r\n"
-
-            await self._send_raw(payload)
-
-            acc = ""
-            end = asyncio.get_running_loop().time() + timeout
-
-            while asyncio.get_running_loop().time() < end:
-                chunk = await self._read_raw()
-                if not chunk:
-                    continue
-                acc += chunk
-                if _OK_RE.search(acc) or _ERR_RE.search(acc):
-                    break
-
-            return acc  # return EXACT raw output
-
-    # ----------------------------------------------------------------------
-    # Parsing helpers EXACTLY as before
-    # ----------------------------------------------------------------------
-    @staticmethod
-    def parse_first_float(text: str) -> Optional[float]:
-        return parse_first_float(text)
-
-    @staticmethod
-    def parse_bool(text: str) -> Optional[bool]:
-        return parse_bool(text)
+    class TimeoutError(Exception):
+        def __init__(self, message, raw=None, cmd=None):
+            super().__init__(message)
+            self.message = message
+            self.raw = raw
+            self.cmd = cmd

--- a/custom_components/tesira_ttp/translations/en.json
+++ b/custom_components/tesira_ttp/translations/en.json
@@ -1,20 +1,28 @@
 {
+    "title": "Tesira Text Protocol (SSH & Telnet)",
+    "common": {},
     "config": {
         "step": {
             "user": {
                 "title": "Connect your Tesira DSP",
-                "description": "Enter the Tesira DSP IP address and port for the TTP Telnet server.",
+                "description": "Enter the Tesira DSP host, port, protocol & credentials for the Tesira Text Protocol server.",
                 "data": {
-                    "ip": "IP Address",
-                    "port": "Port"
+                    "host": "Host",
+                    "port": "Port",
+                    "protocol": "Protocol",
+                    "username": "Username (SSH only)",
+                    "password": "Password (SSH only)"
                 }
             },
             "reconfigure": {
                 "title": "Reconfigure Tesira DSP connection",
-                "description": "Enter the new Tesira DSP IP address and port for the TTP Telnet server.",
+                "description": "Enter the Tesira DSP host, port, protocol & credentials for the Tesira Text Protocol server.",
                 "data": {
-                    "ip": "IP Address",
-                    "port": "Port"
+                    "host": "Host",
+                    "port": "Port",
+                    "protocol": "Protocol",
+                    "username": "Username (SSH only)",
+                    "password": "Password (SSH only)"
                 }
             },
             "control": {
@@ -31,10 +39,13 @@
             }
         },
         "error": {
-            "cannot_connect": "Cannot connect to the Tesira device."
+            "cannot_connect": "Cannot connect to the Tesira device.",
+            "invalid_credentials": "Invalid credentials for SSH connection. Please check your username and password.",
+            "unsupported_authentication": "Authentication is not supported when using Telnet. Please switch to SSH or leave username as default and password blank."
         },
         "abort": {
-            "already_configured": "This Tesira device is already configured."
+            "already_configured": "This Tesira device is already configured.",
+            "reconfigure_successful": "Tesira DSP connection reconfigured successfully."
         }
     },
     "options": {

--- a/custom_components/tesira_ttp/util.py
+++ b/custom_components/tesira_ttp/util.py
@@ -1,15 +1,27 @@
 # #################################################################################################################### #
 # Filename: \custom_components\tesira_ttp\util.py                                                                      #
 # Repository: tesira_ttp                                                                                               #
-# Created Date: Sunday, March 22nd 2026, 1:21:35 AM                                                                    #
-# Last Modified: Sunday, March 22nd 2026, 5:43:18 PM                                                                   #
+# Created Date: Sunday, March 22nd 2026, 10:04:37 PM                                                                   #
+# Last Modified: Thursday, March 26th 2026, 12:25:23 AM                                                                #
 # Original Author: Darnel Kumar                                                                                        #
 # Author Github: https://github.com/Darnel-K                                                                           #
 #                                                                                                                      #
-# This code complies with: https://gist.github.com/Darnel-K/8badda0cabdabb15359350f7af911c90                           #
+# License: GNU Affero General Public License v3.0 only - https://www.gnu.org/licenses/agpl.txt                         #
 # Copyright (c) 2026 Darnel Kumar                                                                                      #
+#                                                                                                                      #
+# This program is free software: you can redistribute it and/or modify                                                 #
+# it under the terms of the GNU Affero General Public License as published                                             #
+# by the Free Software Foundation, either version 3 of the License, or                                                 #
+# (at your option) any later version.                                                                                  #
+#                                                                                                                      #
+# This program is distributed in the hope that it will be useful,                                                      #
+# but WITHOUT ANY WARRANTY; without even the implied warranty of                                                       #
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                                                        #
+# GNU Affero General Public License for more details.                                                                  #
+#                                                                                                                      #
+# You should have received a copy of the GNU Affero General Public License                                             #
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.                                               #
 # #################################################################################################################### #
-
 """Utility helpers for tesira_ttp."""
 
 from __future__ import annotations

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
-    "name": "Tesira TTP Control (Telnet)",
+    "name": "Tesira Text Protocol (SSH & Telnet)",
     "content_in_root": false,
     "homeassistant": "2026.3.2"
 }


### PR DESCRIPTION
* Merge 'misc/no-ref/readme_update' into 'develop' (#12)

* Update README: rebrand, SSH support & badges

Revamp README to rebrand the integration and expand documentation: add multiple badges, new title, WIP notice, and clearer overview of features. Document SSH (TCP/22) support in addition to Telnet, update installation/HACS instructions to the Darnel-K repository, and improve configuration/debugging examples. Add CLI usage example, acknowledgements crediting the original bxthomas repo, license section, and CI/status badges for branches.

* Resolve merge conflict in README.md

* Merge 'misc/no-ref/license_update' into 'develop' (#14)

* Merge 'develop' into 'misc/no-ref/license_update' (#13)

* Updated Config Flow for Initial Configuration (#3)

* Reorder manifest.json fields

Rearrange keys in custom_components/tesira_ttp/manifest.json for consistency and Home Assistant schema/lint compliance. Moved config_flow, documentation, issue_tracker, requirements, and version positions; no functional changes to values.

* Add brand icon for tesira_ttp integration

Add a brand icon PNG for the tesira_ttp custom component at custom_components/tesira_ttp/brand/icon.png. This provides the integration's icon for Home Assistant UI and packaging.

* Add reconfigure flow and schema defaults helper

Replace the previous control step with a reconfigure flow in config_flow: use schema_with_defaults to prefill host/port, perform unique_id checks and a connectivity test, and call async_update_reload_and_abort on success. Introduce util.schema_with_defaults to build voluptuous schemas with runtime default values (new util.py). Update strings.json and translations/en.json to add reconfigure UI text and expand/options steps.

* Reorder manifest.json keys

Rearrange the manifest.json entries: move "config_flow" and "issue_tracker" to new positions to align key ordering. This is a non-functional change (no behavior modifications).

* Remove pyproject.toml

Remove pyproject.toml

* Replace 'host' with 'ip' across project

 - Change CONF_HOST to CONF_IP
 - Change host to ip

Rename configuration key CONF_HOST to CONF_IP and propagate the change throughout the integration: config_flow, __init__, hub, media_player, tesira_client, tesira_cli, strings/translations, and README. Update hub and entity unique IDs / hub keys to use ip:port, adjust CLI flag to --ip, and update user-facing copy to reference the DSP IP address.

* Bump tesira_ttp version to 0.2.0

Update custom_components/tesira_ttp/manifest.json to increment the integration version from 0.1.0 to 0.2.0, reflecting the new release.

* Full re-write of the tesira_client (#5)

* Add asyncssh requirement

 - Add asyncssh>=2.22.0 to the custom_components/tesira_ttp manifest requirements

* Update util.py docstring and add section header

 - Change docstring "Utility helpers for building voluptuous schemas dynamically." to "Utility helpers for tesira_ttp"
 - Add a "Schema Helpers" section header above schema_with_defaults.

* Add TesiraClient (SSH/Telnet) and compatibility wrapper

 - Add new TesiraClient with full SSH and Telnet support
 - Implement fragmentation‑safe TTP command engine
 - Add heartbeat, reconnect, auto re‑subscribe logic
 - Add publish‑token event handling and structured callbacks
 - Add JSON parser for Tesira pseudo‑JSON responses
 - Add device info caching and ping API
 - Add quiet mode for controlled logging
 - Implement TesiraTtpClient wrapper for full backward compatibility
 - Preserve legacy raw output behavior for Home Assistant integration
 - Fix module‑level helper exposure (parse_bool, parse_first_float)

* Replace custom logging with module _LOGGER

 - Remove the instance-level logger/quiet_mode handling and switch to using the module-level _LOGGER for debug/info/warning/error output
 - Update connection, RX/TX, SSH/TELNET and subscription/event logging to use appropriate log levels and include exception details for heartbeat/connect failures
 - Tighten several messages (e.g. TesiraError text and Telnet security warning) and small refactors: assign safe_mode earlier, simplify import, drop quiet_mode argument at instantiation, and adjust a docstring for _read_raw

* Use session buffer for Telnet reads

Change _read_raw to avoid telnetlib3 read conflicts by reading from the session buffer for Telnet connections. SSH still reads directly from the channel with the existing timeout; Telnet waits briefly to let the buffer fill, consumes and clears _client._session.buffer, and returns its contents.

* Improve telnet reader handling and lifecycle

 - Initialize and track the telnet reader task, and make the reader more robust.
 - Added self._telnet_reader_future, store the created reader task, and cancel it on disconnect.
 - Ignore empty data in data_received and return early.
 - Strengthened _telnet_reader_task with EOF detection, logging for cancellation/errors, and safe break on None/empty data.

This fixes a log flooding issue that will cause an out of memory error and the system to crash.

* Bump tesira_ttp manifest version to 0.3.0

Update the custom_components/tesira_ttp/manifest.json version from 0.2.0 to 0.3.0 to reflect the new release of the integration.

* Merge 'misc/no-ref/readme_update' into 'develop' (#12)

* Update README: rebrand, SSH support & badges

Revamp README to rebrand the integration and expand documentation: add multiple badges, new title, WIP notice, and clearer overview of features. Document SSH (TCP/22) support in addition to Telnet, update installation/HACS instructions to the Darnel-K repository, and improve configuration/debugging examples. Add CLI usage example, acknowledgements crediting the original bxthomas repo, license section, and CI/status badges for branches.

* Resolve merge conflict in README.md

* Delete LICENSE



* Add GNU Affero General Public License v3

Added the GNU Affero General Public License version 3 to the project.



* Update README.md

---------



* Merge 'feature/10/rebuild_tesira_cli_tool' into 'develop' (#15)

* Update tesira_client.py

 - Add detection for async callbacks to await them

* Interactive Tesira CLI with SSH/Telnet support

Replace the old telnet-only test utility with a full interactive CLI. Introduces an interactive_shell that connects via TesiraClient (SSH or Telnet), a user-friendly banner, readline optional import, live subscription event printing, and special commands (:json, :ping, :exit). Command-line args changed to --host/--proto/--user/--password/--port. Simplifies flow by removing one-off flags and legacy TesiraTtpClient usage, adds graceful connect/disconnect and improved error handling.

* Use prompt_toolkit for async CLI

Replace blocking input/readline with prompt_toolkit PromptSession and patch_stdout to provide cross-platform, async-safe interactive CLI. Update subscription_printer to redraw the prompt via the session app, wrap the client event callback so it can access the session, and drive user input with session.prompt_async inside patch_stdout. Improve command handling (keep :json and :ping special cases, use client.command for normal commands) and add clean exit handling.

* Add prompt_toolkit dependency

Add prompt_toolkit>=3.0.52 to the requirements in custom_components/tesira_ttp/manifest.json so the integration has the needed interactive prompt library available at runtime.

* Document interactive Tesira TTP CLI usage

Add documentation for custom_components/tesira_ttp/tesira_cli.py: describes a cross-platform interactive shell (uses prompt_toolkit) for sending Tesira TTP commands, receiving publish-token updates, and testing SSH/Telnet connectivity. Lists CLI arguments (host, proto, user, password, port), HA OS `ha core exec` examples for SSH and Telnet (including non-default ports and credentials), and example in-CLI commands and special shortcuts (:json, :ping, :exit). Provides clearer usage guidance and connection scenarios for developers testing the integration.

* Bump tesira_ttp manifest version to 0.4.0

Update manifest.json for custom_components/tesira_ttp to set the integration version from 0.3.0 to 0.4.0. This increments the package version for a new release without other functional changes.

* Merge 'feature/09/transition_to_new_tesira_client' into 'develop' (#19)

* Use host (not ip) for Tesira connections

 - Switch the integration to use `host` instead of `ip` for configuration and unique IDs.

* Remove legacy TesiraTtpClient wrapper

 - Remove the backwards-compatible TesiraTtpClient wrapper and its legacy helpers from tesira_client.py.
 - Deleted module-level parser functions (parse_first_float, parse_bool), raw-response regexes (_OK_RE/_ERR_RE), and the entire TesiraTtpClient class (including send_and_wait, _read_raw, _send_raw, _drain_for and parsing passthroughs).

This cleans up obsolete compatibility code now that TesiraClient supports the needed protocols directly.

* Refactor TesiraHub to use TesiraClient

 - Replace the Telnet-only TesiraTtpClient with TesiraClient
 - Expand TesiraHub initialization to accept host, username, password, port, proto, known_hosts and heartbeat parameters (interval, failure_threshold, jitter) plus safe_mode.
 - Update the key property to use host:port
 - Replace the old send_and_wait with json, add command, disconnect, subscribe and unsubscribe methods, and ensure all client interactions remain serialized via the existing asyncio lock.

This adapts the hub to support SSH/credentialed connections and the newer client API.

* Update Tesira hub init and teardown

 - Change hub usage to match updated TesiraHub API: instantiate with keyword args (host=host, port=port) and call disconnect() instead of close() when unloading entries.

* Simplify .gitignore, remove env/editor ignores

Clean up .gitignore by removing several ignored patterns: *.so, virtual environment folders (.venv, .env, env), OS/IDE files (.DS_Store, .idea), Home Assistant cache (.storage) and pytest cache (.pytest_cache). Retains Python bytecode ignores and .vscode. This reduces the number of excluded entries and centralizes which build/tooling artifacts are ignored.

* Enable safe_mode when creating TesiraHub

 - Pass safe_mode=True to TesiraHub in async_setup_entry so hubs are initialized in safe mode during setup.

* Remove proto='telnet' from TesiraClient calls

 - Update custom_components/tesira_ttp/config_flow.py: remove the explicit proto='telnet' argument from TesiraClient instantiation in two places (quick connectivity probe and user setup path).

This changes switches the integration to use SSH by default. UI menu item to switch protocol will be implemented later to enable end user choice.

* Switch media_player to hub.json API

 - Replace raw send_and_wait string-based calls with TesiraHub.json structured requests in media_player.py.
 - Parse numeric and boolean values from JSON responses (resp['value']).
 - Update mute error handling to check resp['error'].
 - Simplify volume/mute commands to use json() (removing per-call timeouts).
 - Remove unused parse_bool/parse_first_float imports.

* Bump tesira_ttp integration version to 0.5.0

Update manifest.json version for custom_components/tesira_ttp from 0.4.0 to 0.5.0 to reflect the new release. No other files were modified.

* Add AGPL license headers to module files

Insert GNU Affero General Public License v3.0 headers into several module files and update file metadata.

* Updated naming across integration to reflect support for SSH & Telnet

 - Rename user-facing references from 'TTP Telnet' to 'Tesira Text Protocol'
 - Update manifest name accordingly to reflect SSH & Telnet support.
 - Update config flow strings and translations to use the new wording.
 - Change the TesiraHub docstring to "Shared SSH / Telnet client per host:port".

* Set DEFAULT_PORT to 22

 - Change DEFAULT_PORT from 23 to 22 (switch to SSH port).

* Merge 'feature/17/config_flow_protocol_switch' into 'develop' (#20)

* Add protocol option (SSH/Telnet) to config flow

 - Introduce a protocol selection for Tesira TTP setup
 - Add CONF_PROTO and DEFAULT_PROTO in consts
 - Expose a selector (SSH/Telnet) in the user/reconfigure schemas, and pass the selected proto to TesiraClient during connectivity probes.

* Include protocol in unique id and hub key

 - Add protocol (CONF_PROTO) to configuration flow, hub keys, and hub/client construction so multiple devices using different protocols at the same host:port are treated separately.
 - Updated async_set_unique_id and unique-id collision checks to use host:port:proto, store protocol in the config context/data, and pass proto when creating TesiraHub/TesiraClient.
 - Adjusted media_player to look up hubs by the new hub key. This prevents accidental deduplication of entries that differ only by protocol.

* Bump tesira_ttp version to 0.6.0

Update custom_components/tesira_ttp/manifest.json to bump the integration version from 0.5.0 to 0.6.0 to reflect the new release.

* Rename integration display name in hacs.json

 - Change the integration name from "Tesira TTP Control (Telnet)" to "Tesira Text Protocol (SSH & Telnet)" to reflect support for SSH in addition to Telnet.

* Add optional SSH username/password support

 - Introduce CONF_USER/CONF_PASS and DEFAULT_USER/DEFAULT_PASS and wire them through the config flow and component.
 - Updated config form to now accept optional username and password, credentials are included in created/updated config entries, and passed to TesiraClient and TesiraHub when establishing connections.
 - UI strings/translations updated to show "Username (SSH only)" and "Password (SSH only)".

This enables authenticated SSH connections to Tesira devices.

* Bump tesira_ttp version to 0.7.0

Update custom_components/tesira_ttp/manifest.json version field from 0.6.0 to 0.7.0 to reflect the new release.

* Implemented maximum retries for TesiraClient Connect

 - Remove attempt optional argument for TesiraClient connect method
 - Add max_retries optional argument to TesiraClient connect method
 - Implement maximum retry logic to TesiraClient connect method to prevent an endless loop

* Updated TesiraClient connection attempt error message

 - Changed max connection attempts error message

* Report SSH auth errors and add message

 - Add explicit handling for SSH authentication failures and surface a user-friendly error.

TesiraClient now maps asyncssh.PermissionDenied to a new TesiraSSHPermissionError and defines client-specific exception classes. The config flow catches TesiraSSHPermissionError during user and reconfigure steps and returns an "invalid_credentials" form error.

 - Add corresponding "invalid_credentials" strings to strings.json and translations/en.json.

* Refactor TesiraClient exceptions and handling

Clarify and consolidate error types in tesira_client.py and update config flow handling.

 - Changed generic/ambiguous exceptions with specific classes (CommandError, ProtocolError, JSONParseError, InvalidCredentials, AuthenticationUnsupportedError, TimeoutError) and adjusted raises to use them.
 - Updated connection error handling to raise ConnectionError on max retries.
 - Changed telnet/auth validation to raise AuthenticationUnsupportedError/ProtocolError, and made unsubscribe handle CommandError.
 - Updated config_flow to catch InvalidCredentials instead of the removed TesiraSSHPermissionError.

* Handle unsupported auth and add translations

 - Add Catch TesiraClient.AuthenticationUnsupportedError in config flow (user and reconfigure steps) and map it to a new 'unsupported_authentication' form error so users get a clear message when authentication is not available (e.g., Telnet).
 - Add corresponding UI strings/translations (title, common, unsupported_authentication error, and reconfigure_successful abort message).

* Bump tesira_ttp version to 0.8.0

 - Update custom_components/tesira_ttp/manifest.json to bump the integration version from 0.7.0 to 0.8.0.

---------