### PR TITLE
Add support for multiple devices within a single Tesira system

### DIFF
--- a/custom_components/tesira_ttp/__init__.py
+++ b/custom_components/tesira_ttp/__init__.py
@@ -2,7 +2,7 @@
 # Filename: \custom_components\tesira_ttp\__init__.py                                                                  #
 # Repository: tesira_ttp                                                                                               #
 # Created Date: Thursday, March 19th 2026, 12:56:52 AM                                                                 #
-# Last Modified: Friday, April 3rd 2026, 11:06:18 PM                                                                   #
+# Last Modified: Tuesday, April 7th 2026, 11:21:40 PM                                                                  #
 # Original Author: Darnel Kumar                                                                                        #
 # Author Github: https://github.com/Darnel-K                                                                           #
 #                                                                                                                      #
@@ -25,15 +25,15 @@
 from __future__ import annotations
 
 import logging
+import copy
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import device_registry as dr
 
-from .const import DOMAIN, PLATFORMS, CONF_IP, CONF_PORT, CONF_PROTO, CONF_USER, CONF_PASS, CONF_DEVICE_INFO
+from .const import DOMAIN, PLATFORMS, CONF_HOST, CONF_PORT, CONF_PROTO, CONF_USER, CONF_PASS, CONF_DEVICES, DEFAULT_DEVICES
 from .hub import TesiraHub
-from .util import gen_hub_key
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -52,15 +52,22 @@ async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> Non
     await hass.config_entries.async_reload(entry.entry_id)
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    host = entry.data[CONF_IP]
-    port = entry.data[CONF_PORT]
-    proto = entry.data[CONF_PROTO]
-    user = entry.data.get(CONF_USER)
-    pwrd = entry.data.get(CONF_PASS)
-    device_info = entry.data.get(CONF_DEVICE_INFO)
+    devices = copy.deepcopy(entry.data.get(CONF_DEVICES, DEFAULT_DEVICES))
+    primary_device_id = devices.get("primary")
+    if not primary_device_id or primary_device_id not in devices["items"]:
+        _LOGGER.error("Invalid or missing primary device in config entry %s", entry.entry_id)
+        return False
+    primary_device = devices["items"][primary_device_id]
+    conn_info = primary_device["connection_info"]
+    auth_credentials = conn_info.get("auth", {})
+    host = conn_info.get(CONF_HOST)
+    port = conn_info.get(CONF_PORT)
+    proto = conn_info.get(CONF_PROTO)
+    user = auth_credentials.get(CONF_USER)
+    pwrd = auth_credentials.get(CONF_PASS)
 
     hubs: dict[str, TesiraHub] = hass.data[DOMAIN][DATA_HUBS]
-    hubkey = gen_hub_key(deviceModel=device_info.get("deviceModel"), deviceRevision=device_info.get("deviceRevision"), serialNumber=device_info.get("serialNumber"))
+    hubkey = entry.entry_id
     hub = hubs.get(hubkey)
     if hub is None:
         hub = TesiraHub(host=host, port=port, proto=proto, username=user, password=pwrd, safe_mode=True)
@@ -70,7 +77,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data[DOMAIN][DATA_ENTRY_HUBKEY][entry.entry_id] = hubkey
 
     device_registry = dr.async_get(hass)
-    device_registry.async_get_or_create(config_entry_id=entry.entry_id, identifiers={(DOMAIN, hubkey)}, manufacturer="Biamp", model=device_info.get("deviceModel"), model_id=device_info.get("deviceModel"), name=f"Biamp - {device_info.get('deviceModel')} ({device_info.get('serialNumber')})", sw_version=device_info.get("firmwareVersion"), hw_version=device_info.get("deviceRevision"), serial_number=device_info.get("serialNumber"))
+    for device_id, device in devices["items"].items():
+        device_info = device.get("device_info", {})
+        device_registry.async_get_or_create(config_entry_id=entry.entry_id, identifiers={(DOMAIN, device_id)}, manufacturer=device_info.get("manufacturer"), model=device_info.get("model"), model_id=device_info.get("model_id"), name=device_info.get('name'), sw_version=device_info.get("sw_version"), hw_version=device_info.get("hw_version"), serial_number=device_info.get("serial_number"))
 
     entry.async_on_unload(entry.add_update_listener(_async_update_listener))
 

--- a/custom_components/tesira_ttp/__init__.py
+++ b/custom_components/tesira_ttp/__init__.py
@@ -2,7 +2,7 @@
 # Filename: \custom_components\tesira_ttp\__init__.py                                                                  #
 # Repository: tesira_ttp                                                                                               #
 # Created Date: Thursday, March 19th 2026, 12:56:52 AM                                                                 #
-# Last Modified: Tuesday, April 7th 2026, 11:21:40 PM                                                                  #
+# Last Modified: Sunday, April 12th 2026, 10:09:23 PM                                                                  #
 # Original Author: Darnel Kumar                                                                                        #
 # Author Github: https://github.com/Darnel-K                                                                           #
 #                                                                                                                      #
@@ -32,19 +32,17 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import device_registry as dr
 
-from .const import DOMAIN, PLATFORMS, CONF_HOST, CONF_PORT, CONF_PROTO, CONF_USER, CONF_PASS, CONF_DEVICES, DEFAULT_DEVICES
+from .const import DOMAIN, PLATFORMS, DICT_KEYS, DEFAULTS
 from .hub import TesiraHub
 
 _LOGGER = logging.getLogger(__name__)
 
-DATA_HUBS = "hubs"
-DATA_ENTRY_HUBKEY = "entry_hubkey"
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN].setdefault(DATA_HUBS, {})
-    hass.data[DOMAIN].setdefault(DATA_ENTRY_HUBKEY, {})
+    hass.data[DOMAIN].setdefault(DICT_KEYS["DATA_HUBS"], {})
+    hass.data[DOMAIN].setdefault(DICT_KEYS["DATA_ENTRY_HUBKEY"], {})
     return True
 
 async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
@@ -52,7 +50,7 @@ async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> Non
     await hass.config_entries.async_reload(entry.entry_id)
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    devices = copy.deepcopy(entry.data.get(CONF_DEVICES, DEFAULT_DEVICES))
+    devices = copy.deepcopy(entry.data.get(DICT_KEYS["DEVICES"], DEFAULTS["DEVICES"]))
     primary_device_id = devices.get("primary")
     if not primary_device_id or primary_device_id not in devices["items"]:
         _LOGGER.error("Invalid or missing primary device in config entry %s", entry.entry_id)
@@ -60,13 +58,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     primary_device = devices["items"][primary_device_id]
     conn_info = primary_device["connection_info"]
     auth_credentials = conn_info.get("auth", {})
-    host = conn_info.get(CONF_HOST)
-    port = conn_info.get(CONF_PORT)
-    proto = conn_info.get(CONF_PROTO)
-    user = auth_credentials.get(CONF_USER)
-    pwrd = auth_credentials.get(CONF_PASS)
+    host = conn_info.get(DICT_KEYS["HOST"])
+    port = conn_info.get(DICT_KEYS["PORT"])
+    proto = conn_info.get(DICT_KEYS["PROTO"])
+    user = auth_credentials.get(DICT_KEYS["USER"])
+    pwrd = auth_credentials.get(DICT_KEYS["PASS"])
 
-    hubs: dict[str, TesiraHub] = hass.data[DOMAIN][DATA_HUBS]
+    hubs: dict[str, TesiraHub] = hass.data[DOMAIN][DICT_KEYS["DATA_HUBS"]]
     hubkey = entry.entry_id
     hub = hubs.get(hubkey)
     if hub is None:
@@ -74,7 +72,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hubs[hubkey] = hub
         _LOGGER.debug("Created Tesira hub for %s", hubkey)
 
-    hass.data[DOMAIN][DATA_ENTRY_HUBKEY][entry.entry_id] = hubkey
+    hass.data[DOMAIN][DICT_KEYS["DATA_ENTRY_HUBKEY"]][entry.entry_id] = hubkey
 
     device_registry = dr.async_get(hass)
     for device_id, device in devices["items"].items():
@@ -89,11 +87,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
-    hubkey = hass.data[DOMAIN][DATA_ENTRY_HUBKEY].pop(entry.entry_id, None)
+    hubkey = hass.data[DOMAIN][DICT_KEYS["DATA_ENTRY_HUBKEY"]].pop(entry.entry_id, None)
     if hubkey:
-        hubs: dict[str, TesiraHub] = hass.data[DOMAIN][DATA_HUBS]
+        hubs: dict[str, TesiraHub] = hass.data[DOMAIN][DICT_KEYS["DATA_HUBS"]]
         # If no other entries reference this hubkey, close it.
-        if hubkey not in hass.data[DOMAIN][DATA_ENTRY_HUBKEY].values():
+        if hubkey not in hass.data[DOMAIN][DICT_KEYS["DATA_ENTRY_HUBKEY"]].values():
             hub = hubs.pop(hubkey, None)
             if hub:
                 await hub.disconnect()

--- a/custom_components/tesira_ttp/binary_sensor.py
+++ b/custom_components/tesira_ttp/binary_sensor.py
@@ -1,8 +1,8 @@
 # #################################################################################################################### #
 # Filename: \custom_components\tesira_ttp\binary_sensor.py                                                             #
 # Repository: tesira_ttp                                                                                               #
-# Created Date: Thursday, March 19th 2026, 12:56:52 AM                                                                 #
-# Last Modified: Sunday, April 12th 2026, 10:09:23 PM                                                                  #
+# Created Date: Saturday, April 4th 2026, 5:22:28 PM                                                                   #
+# Last Modified: Sunday, April 12th 2026, 11:23:04 PM                                                                  #
 # Original Author: Darnel Kumar                                                                                        #
 # Author Github: https://github.com/Darnel-K                                                                           #
 #                                                                                                                      #
@@ -50,11 +50,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     for device_id, device in devices["items"].items():
         hub_entities.append(TesiraNetConnBinarySensor(hub, device_id, device))
 
-    async_add_entities(hub_entities)
+    async_add_entities(hub_entities, update_before_add=True)
 
 class TesiraNetConnBinarySensor(BinarySensorEntity):
     """Binary sensor for Tesira connection status."""
 
+    _attr_has_entity_name = True
     _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
     _attr_should_poll = True
 
@@ -67,6 +68,7 @@ class TesiraNetConnBinarySensor(BinarySensorEntity):
         self._attr_name = f"Network Connection Status (SN:{self._device_info.get('serial_number')})"
         self._attr_unique_id = f"tesira_ttp_{self._device_info.get('serial_number')}_netconnstate".lower()
         self._attr_is_on = False
+        self._attr_available = True
 
     @property
     def is_on(self) -> bool | None:
@@ -98,6 +100,7 @@ class TesiraNetConnBinarySensor(BinarySensorEntity):
 class TesiraHubConnBinarySensor(BinarySensorEntity):
     """Binary sensor for Tesira hub connection status."""
 
+    _attr_has_entity_name = True
     _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
     _attr_should_poll = True
 
@@ -107,6 +110,7 @@ class TesiraHubConnBinarySensor(BinarySensorEntity):
         self._attr_name = f"Hub Connection Status ({self._hubkey})"
         self._attr_unique_id = f"tesira_ttp_{self._hubkey}_hubconnstate".lower()
         self._attr_is_on = False
+        self._attr_available = True
 
     @property
     def is_on(self) -> bool | None:

--- a/custom_components/tesira_ttp/binary_sensor.py
+++ b/custom_components/tesira_ttp/binary_sensor.py
@@ -1,8 +1,8 @@
 # #################################################################################################################### #
 # Filename: \custom_components\tesira_ttp\binary_sensor.py                                                             #
 # Repository: tesira_ttp                                                                                               #
-# Created Date: Saturday, April 4th 2026, 5:22:28 PM                                                                   #
-# Last Modified: Wednesday, April 8th 2026, 9:44:13 PM                                                                 #
+# Created Date: Thursday, March 19th 2026, 12:56:52 AM                                                                 #
+# Last Modified: Sunday, April 12th 2026, 10:09:23 PM                                                                  #
 # Original Author: Darnel Kumar                                                                                        #
 # Author Github: https://github.com/Darnel-K                                                                           #
 #                                                                                                                      #
@@ -34,15 +34,15 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from .const import DOMAIN, CONF_HOST, CONF_DEVICES, DEFAULT_DEVICES
+from .const import DOMAIN, DICT_KEYS, DEFAULTS
 from .hub import TesiraHub
 
 _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities):
     hubkey = entry.entry_id
-    hub: TesiraHub = hass.data[DOMAIN]["hubs"][hubkey]
-    devices = copy.deepcopy(entry.data.get(CONF_DEVICES, DEFAULT_DEVICES))
+    hub: TesiraHub = hass.data[DOMAIN][DICT_KEYS["DATA_HUBS"]][hubkey]
+    devices = copy.deepcopy(entry.data.get(DICT_KEYS["DEVICES"], DEFAULTS["DEVICES"]))
 
     hub_entities = []
     hub_entities.append(TesiraHubConnBinarySensor(hub, hubkey))
@@ -93,7 +93,7 @@ class TesiraNetConnBinarySensor(BinarySensorEntity):
             return False
 
     async def async_update(self):
-        self._attr_is_on = await self._async_ping(self._device_connection_info.get(CONF_HOST))
+        self._attr_is_on = await self._async_ping(self._device_connection_info.get(DICT_KEYS["HOST"]))
 
 class TesiraHubConnBinarySensor(BinarySensorEntity):
     """Binary sensor for Tesira hub connection status."""

--- a/custom_components/tesira_ttp/binary_sensor.py
+++ b/custom_components/tesira_ttp/binary_sensor.py
@@ -1,8 +1,8 @@
 # #################################################################################################################### #
 # Filename: \custom_components\tesira_ttp\binary_sensor.py                                                             #
 # Repository: tesira_ttp                                                                                               #
-# Created Date: Thursday, March 19th 2026, 12:56:52 AM                                                                 #
-# Last Modified: Saturday, April 4th 2026, 3:12:25 PM                                                                  #
+# Created Date: Saturday, April 4th 2026, 5:22:28 PM                                                                   #
+# Last Modified: Wednesday, April 8th 2026, 9:44:13 PM                                                                 #
 # Original Author: Darnel Kumar                                                                                        #
 # Author Github: https://github.com/Darnel-K                                                                           #
 #                                                                                                                      #
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import logging
 import asyncio
+import copy
 from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
     BinarySensorDeviceClass,
@@ -33,19 +34,23 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from .const import DOMAIN, CONF_IP, CONF_PORT, CONF_DEVICE_INFO
+from .const import DOMAIN, CONF_HOST, CONF_DEVICES, DEFAULT_DEVICES
 from .hub import TesiraHub
-from .util import gen_hub_key
 
 _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities):
-    host = entry.data[CONF_IP]
-    device_info = entry.data[CONF_DEVICE_INFO]
-    hubkey = gen_hub_key(deviceModel=device_info.get("deviceModel"), deviceRevision=device_info.get("deviceRevision"), serialNumber=device_info.get("serialNumber"))
+    hubkey = entry.entry_id
     hub: TesiraHub = hass.data[DOMAIN]["hubs"][hubkey]
+    devices = copy.deepcopy(entry.data.get(CONF_DEVICES, DEFAULT_DEVICES))
 
-    async_add_entities([TesiraNetConnBinarySensor(hub, hubkey, host, device_info), TesiraHubConnBinarySensor(hub, hubkey, device_info)])
+    hub_entities = []
+    hub_entities.append(TesiraHubConnBinarySensor(hub, hubkey))
+
+    for device_id, device in devices["items"].items():
+        hub_entities.append(TesiraNetConnBinarySensor(hub, device_id, device))
+
+    async_add_entities(hub_entities)
 
 class TesiraNetConnBinarySensor(BinarySensorEntity):
     """Binary sensor for Tesira connection status."""
@@ -53,13 +58,14 @@ class TesiraNetConnBinarySensor(BinarySensorEntity):
     _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
     _attr_should_poll = True
 
-    def __init__(self, hub: TesiraHub, hubkey: str, host: str, device_info: dict) -> None:
+    def __init__(self, hub: TesiraHub, device_id: str, device: dict) -> None:
         self._hub = hub
-        self._hubkey = hubkey
-        self._host = host
-        self._device_info = device_info
-        self._attr_name = f"Network Connection Status (SN:{device_info.get('serialNumber')})"
-        self._attr_unique_id = f"tesira_ttp_{device_info.get('serialNumber')}_netconnstate".lower()
+        self._device_id = device_id
+        self._device = device
+        self._device_info = device.get("device_info", {})
+        self._device_connection_info = device.get("connection_info", {})
+        self._attr_name = f"Network Connection Status (SN:{self._device_info.get('serial_number')})"
+        self._attr_unique_id = f"tesira_ttp_{self._device_info.get('serial_number')}_netconnstate".lower()
         self._attr_is_on = False
 
     @property
@@ -68,7 +74,7 @@ class TesiraNetConnBinarySensor(BinarySensorEntity):
 
     @property
     def device_info(self):
-        return {"identifiers": {(DOMAIN, self._hubkey)}}
+        return {"identifiers": {(DOMAIN, self._device_id)}}
 
     async def _async_ping(self, host: str) -> bool:
         """Ping the host using the OS ping command."""
@@ -87,7 +93,7 @@ class TesiraNetConnBinarySensor(BinarySensorEntity):
             return False
 
     async def async_update(self):
-        self._attr_is_on = await self._async_ping(self._host)
+        self._attr_is_on = await self._async_ping(self._device_connection_info.get(CONF_HOST))
 
 class TesiraHubConnBinarySensor(BinarySensorEntity):
     """Binary sensor for Tesira hub connection status."""
@@ -95,21 +101,16 @@ class TesiraHubConnBinarySensor(BinarySensorEntity):
     _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
     _attr_should_poll = True
 
-    def __init__(self, hub: TesiraHub, hubkey: str, device_info: dict) -> None:
+    def __init__(self, hub: TesiraHub, hubkey: str) -> None:
         self._hub = hub
         self._hubkey = hubkey
-        self._device_info = device_info
-        self._attr_name = f"Hub Connection Status (SN:{device_info.get('serialNumber')})"
-        self._attr_unique_id = f"tesira_ttp_{device_info.get('serialNumber')}_hubconnstate".lower()
+        self._attr_name = f"Hub Connection Status ({self._hubkey})"
+        self._attr_unique_id = f"tesira_ttp_{self._hubkey}_hubconnstate".lower()
         self._attr_is_on = False
 
     @property
     def is_on(self) -> bool | None:
             return self._attr_is_on
-
-    @property
-    def device_info(self):
-        return {"identifiers": {(DOMAIN, self._hubkey)}}
 
     async def async_update(self):
         self._attr_is_on = self._hub.is_connected

--- a/custom_components/tesira_ttp/config_flow.py
+++ b/custom_components/tesira_ttp/config_flow.py
@@ -2,7 +2,7 @@
 # Filename: \custom_components\tesira_ttp\config_flow.py                                                               #
 # Repository: tesira_ttp                                                                                               #
 # Created Date: Thursday, March 19th 2026, 12:56:52 AM                                                                 #
-# Last Modified: Saturday, April 4th 2026, 9:49:42 PM                                                                  #
+# Last Modified: Sunday, April 5th 2026, 6:59:30 PM                                                                    #
 # Original Author: Darnel Kumar                                                                                        #
 # Author Github: https://github.com/Darnel-K                                                                           #
 #                                                                                                                      #
@@ -43,6 +43,7 @@ from .const import (
     CONF_PASS,
     CONF_DEVICE_INFO,
     CONF_CONTROLS,
+    CONF_ITEMS,
     CONF_CONTROL_NAME,
     CONF_INSTANCE_TAG,
     CONF_CHANNEL,
@@ -61,6 +62,7 @@ from .const import (
 )
 from .tesira_client import TesiraClient
 from .util import schema_with_defaults, gen_hub_key, TesiraTTPException
+from .schemas import _device_schema
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -96,6 +98,16 @@ def _control_schema(defaults: dict[str, Any] | None = None) -> vol.Schema:
 
 class TesiraTtpConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 1
+
+    @property
+    def _primary_device(self) -> dict[str, Any]:
+        items = dict(self.config_entry.options.get(CONF_ITEMS, {}))
+        return (items.get("devices")).get("primary", {})
+
+    @property
+    def _secondary_devices(self) -> list[dict[str, Any]]:
+        items = dict(self.config_entry.options.get(CONF_ITEMS, {}))
+        return (items.get("devices")).get("secondary", [])
 
     async def async_step_user(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         errors: dict[str, str] = {}

--- a/custom_components/tesira_ttp/config_flow.py
+++ b/custom_components/tesira_ttp/config_flow.py
@@ -2,7 +2,7 @@
 # Filename: \custom_components\tesira_ttp\config_flow.py                                                               #
 # Repository: tesira_ttp                                                                                               #
 # Created Date: Thursday, March 19th 2026, 12:56:52 AM                                                                 #
-# Last Modified: Sunday, April 5th 2026, 9:19:42 PM                                                                    #
+# Last Modified: Wednesday, April 8th 2026, 9:16:23 PM                                                                 #
 # Original Author: Darnel Kumar                                                                                        #
 # Author Github: https://github.com/Darnel-K                                                                           #
 #                                                                                                                      #
@@ -25,6 +25,7 @@
 from __future__ import annotations
 
 import logging
+import copy
 from typing import Any
 
 import voluptuous as vol
@@ -36,175 +37,284 @@ import homeassistant.helpers.config_validation as cv
 
 from .const import (
     DOMAIN,
-    CONF_IP,
+    CONF_HUB_TITLE,
+    CONF_HOST,
     CONF_PORT,
     CONF_PROTO,
     CONF_USER,
     CONF_PASS,
-    CONF_DEVICE_INFO,
     CONF_CONTROLS,
-    CONF_ITEMS,
+    CONF_DEVICES,
     CONF_CONTROL_NAME,
     CONF_INSTANCE_TAG,
     CONF_CHANNEL,
     CONF_MIN_DB,
     CONF_MAX_DB,
     CONF_STEP_DB,
-    DEFAULT_PORT,
-    DEFAULT_PROTO,
-    DEFAULT_USER,
-    DEFAULT_PASS,
     DEFAULT_CONTROL_NAME,
-    DEFAULT_CHANNEL,
-    DEFAULT_MIN_DB,
-    DEFAULT_MAX_DB,
-    DEFAULT_STEP_DB
+    DEFAULT_DEVICES,
+    MODE_INIT,
+    MODE_RECONFIGURE
 )
 from .tesira_client import TesiraClient
-from .util import gen_hub_key, TesiraTTPException
-from .schemas import _device_schema, _control_schema
+from .util import gen_device_id, gen_device_dict, _redact_device, TesiraTTPException
+from .schemas import _device_schema, _control_schema, _hub
 
 _LOGGER = logging.getLogger(__name__)
-
-STEP_USER_SCHEMA = vol.Schema(
-    {
-        vol.Required(CONF_IP): cv.string,
-        vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
-        vol.Required(CONF_PROTO, default=DEFAULT_PROTO): selector({
-            "select": {
-                "options": [
-                    {"value": "ssh", "label": "SSH"},
-                    {"value": "telnet", "label": "Telnet"}
-                ]
-            }
-        }),
-        vol.Optional(CONF_USER, default=DEFAULT_USER): cv.string,
-        vol.Optional(CONF_PASS, default=DEFAULT_PASS): cv.string
-    }
-)
 
 class TesiraTtpConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 1
 
     @property
-    def _primary_device(self) -> dict[str, Any]:
-        items = dict(self.config_entry.options.get(CONF_ITEMS, {}))
-        return (items.get("devices", {})).get("primary", {})
+    def _devices(self) -> dict[str, Any]:
+        entry = self.context.get("entry")
+        if entry is None:
+            return copy.deepcopy(DEFAULT_DEVICES)
 
-    @property
-    def _secondary_devices(self) -> list[dict[str, Any]]:
-        items = dict(self.config_entry.options.get(CONF_ITEMS, {}))
-        return (items.get("devices", [])).get("secondary", [])
+        return copy.deepcopy(entry.data.get(CONF_DEVICES, DEFAULT_DEVICES))
+
+    def _name_map(self) -> dict[str, str]:
+        """Return a mapping of human-readable device names to device IDs."""
+
+        devices = self._devices.get("items", {})
+        name_map: dict[str, str] = {}
+        seen_names: set[str] = set()
+
+        for device_id, device in devices.items():
+            info = device.get("device_info", {})
+            base_name = info.get("name", "Unknown Device")
+            serial = info.get("serial_number")
+
+            name = base_name
+
+            # Ensure uniqueness of displayed names
+            if name in seen_names:
+                suffix = serial or device_id[:8]
+                name = f"{base_name} ({suffix})"
+
+            seen_names.add(name)
+            name_map[name] = device_id
+
+        return dict(sorted(name_map.items()))
+
+    async def _connectivity_test(self, host: str, port: int, proto: str, user: str, pwrd: str) -> tuple[dict[str, Any] | None, str | None]:
+        try:
+            client = TesiraClient(host=host, port=port, proto=proto, username=user, password=pwrd)
+            await client.connect()
+            if client._conn is not None:
+                try:
+                    device_info = await client.device_info()
+                    device_info = device_info["info"]
+                    _LOGGER.debug("Connectivity test successful: Device Info: %s", device_info)
+                    return device_info, None
+                except Exception as e:
+                    _LOGGER.debug("Connectivity test succeeded but failed to get device info: %s", e)
+                    return None, "device_info_failed"
+                finally:
+                    await client.disconnect()
+            else:
+                raise ConnectionError("Failed to establish connection")
+        except TesiraClient.InvalidCredentials as e:
+            _LOGGER.debug("Connectivity test failed: %s", e)
+            return None, "invalid_credentials"
+        except TesiraClient.AuthenticationUnsupportedError as e:
+            _LOGGER.debug("Connectivity test failed: %s", e)
+            return None, "unsupported_authentication"
+        except Exception as e:
+            _LOGGER.exception("Connectivity test failed: %s", e)
+            return None, "cannot_connect"
 
     async def async_step_user(self, user_input: dict[str, Any] | None = None) -> FlowResult:
-        errors: dict[str, str] = {}
+        form_errors: dict[str, str] = {}
+        form_data: dict[str, Any] = {}
 
         if user_input is not None:
-            host = user_input[CONF_IP]
-            port = user_input[CONF_PORT]
-            proto = user_input[CONF_PROTO]
-            user = user_input[CONF_USER]
+            form_data[CONF_HUB_TITLE] = user_input[CONF_HUB_TITLE]
+
+            self.context[CONF_HUB_TITLE] = form_data[CONF_HUB_TITLE]
+            return self.async_show_form(step_id="add_device", data_schema=_device_schema(), errors={})
+
+        return self.async_show_form(step_id="user", data_schema=_hub(form_data), errors=form_errors)
+
+    async def async_step_add_device(self, user_input: dict[str, Any] | None = None) -> FlowResult:
+        form_errors: dict[str, str] = {}
+        entry = self.context.get("entry")
+        mode = MODE_RECONFIGURE if entry else MODE_INIT
+        form_data: dict[str, Any] = {}
+
+        if user_input is not None:
+            form_data[CONF_HOST] = user_input[CONF_HOST]
+            form_data[CONF_PORT] = user_input[CONF_PORT]
+            form_data[CONF_PROTO] = user_input[CONF_PROTO]
+            form_data[CONF_USER] = user_input[CONF_USER]
             pwrd = user_input[CONF_PASS]
 
-            # Quick connectivity probe.
-            try:
-                client = TesiraClient(host=host, port=port, proto=proto, username=user, password=pwrd)
-                await client.connect()
-                if client._conn is not None:
-                    try:
-                        device_info = await client.device_info()
-                        await client.disconnect()
-                        device_info = device_info["info"]
-                        _LOGGER.debug("Connectivity test successful: Device Info: %s", device_info)
-                        hub_key = gen_hub_key(deviceModel=device_info["deviceModel"], deviceRevision=device_info["deviceRevision"], serialNumber=device_info["serialNumber"])
-                        # Use device_info as unique key so a Tesira device is only configured once.
-                        await self.async_set_unique_id(hub_key)
-                        self._abort_if_unique_id_configured()
-                    except Exception as e:
-                        _LOGGER.debug("Connectivity test succeeded but failed to get device info: %s", e)
-                        errors["base"] = "device_info_failed"
-                        await client.disconnect()
-                        return self.async_show_form(step_id="user", data_schema=_device_schema(), errors=errors)
-                else:
-                    raise ConnectionError("Failed to establish connection")
-            except TesiraClient.InvalidCredentials as e:
-                _LOGGER.debug("Connectivity test failed: %s", e)
-                errors["base"] = "invalid_credentials"
-                return self.async_show_form(step_id="user", data_schema=_device_schema(), errors=errors)
-            except TesiraClient.AuthenticationUnsupportedError as e:
-                _LOGGER.debug("Connectivity test failed: %s", e)
-                errors["base"] = "unsupported_authentication"
-                return self.async_show_form(step_id="user", data_schema=_device_schema(), errors=errors)
-            except Exception as e:
-                _LOGGER.debug("Connectivity test failed: %s", e)
-                errors["base"] = "cannot_connect"
-                return self.async_show_form(step_id="user", data_schema=_device_schema(), errors=errors)
+            devices = self._devices
 
-            title = f"Biamp - {device_info['deviceModel']} - {device_info['serialNumber']} - {host}:{port}"
-            return self.async_create_entry(title=title, data={CONF_IP: host, CONF_PORT: port, CONF_PROTO: proto, CONF_USER: user, CONF_PASS: pwrd, CONF_DEVICE_INFO: device_info})
+            device_info, error = await self._connectivity_test(form_data[CONF_HOST], form_data[CONF_PORT], form_data[CONF_PROTO], form_data[CONF_USER], pwrd)
+            if error:
+                return self.async_show_form(step_id="add_device", data_schema=_device_schema(form_data), errors={"base": error})
 
-        return self.async_show_form(step_id="user", data_schema=_device_schema(), errors=errors)
+            device_id = gen_device_id(deviceModel=device_info["deviceModel"], deviceRevision=device_info["deviceRevision"], serialNumber=device_info["serialNumber"])
+            device = gen_device_dict(form_data[CONF_HOST], form_data[CONF_PORT], form_data[CONF_PROTO], form_data[CONF_USER], pwrd, device_info)
+
+            if device_id in devices["items"]:
+                _LOGGER.debug("Device with ID %s already exists in config, skipping addition", device_id)
+                form_errors["base"] = "device_exists"
+                return self.async_show_form(step_id="add_device", data_schema=_device_schema(form_data), errors=form_errors)
+
+            if mode == MODE_INIT:
+                title: str = self.context.get(CONF_HUB_TITLE)
+                devices["items"][device_id] = device
+                devices["primary"] = device_id
+                _LOGGER.debug("Added new device: %s", _redact_device(device))
+                return self.async_create_entry(title=title, data={CONF_DEVICES: devices})
+            else:
+                entry = self.context['entry']
+                devices["items"][device_id] = device
+                _LOGGER.debug("Added new device: %s", _redact_device(device))
+                return self.async_update_reload_and_abort(entry, data={CONF_DEVICES: devices}, reason="device_added")
+
+        return self.async_show_form(step_id="add_device", data_schema=_device_schema(), errors=form_errors)
 
     async def async_step_reconfigure(self, user_input: dict[str, Any] | None = None) -> FlowResult:
-        errors: dict[str, str] = {}
+        self.context['entry'] = self._get_reconfigure_entry()
+        return self.async_show_menu(
+            step_id="reconfigure",
+            menu_options=["edit_hub_title", "devices"],
+        )
 
-        entry = self._get_reconfigure_entry()
-        defaults = {
-            CONF_IP: entry.data.get(CONF_IP),
-            CONF_PORT: entry.data.get(CONF_PORT),
-            CONF_PROTO: entry.data.get(CONF_PROTO),
-            CONF_USER: entry.data.get(CONF_USER)
-        }
-        existing_device_info = entry.data.get(CONF_DEVICE_INFO)
+    async def async_step_devices(self, user_input: dict[str, Any] | None = None) -> FlowResult:
+        return self.async_show_menu(
+            step_id="devices",
+            menu_options=["add_device", "select_device", "remove_device", "change_primary"],
+        )
+
+    async def async_step_select_device(self, user_input: dict[str, Any] | None = None) -> FlowResult:
+        names = self._name_map()
+        if not names:
+            return self.async_abort(reason="no_devices")
+
+        if user_input is None:
+            schema = vol.Schema({vol.Required("select"): vol.In(list(names.keys()))})
+            return self.async_show_form(step_id="select_device", data_schema=schema, errors={})
+
+        edit_id = names[user_input["select"]]
+        self.context["edit_id"] = edit_id
+        defaults = self._devices["items"][edit_id]["connection_info"]
+        return self.async_show_form(step_id="edit_device", data_schema=_device_schema(defaults), errors={})
+
+    async def async_step_edit_device(self, user_input: dict[str, Any] | None = None) -> FlowResult:
+        form_errors: dict[str, str] = {}
+        form_data: dict[str, Any] = {}
+        entry = self.context.get("entry")
+        edit_id = self.context.get("edit_id")
+        if edit_id is None:
+            return self.async_abort(reason="unknown")
+        existing_device = self._devices["items"].get(edit_id)
+        defaults = existing_device["connection_info"] if existing_device else {}
 
         if user_input is not None:
-            host = user_input[CONF_IP]
-            port = user_input[CONF_PORT]
-            proto = user_input[CONF_PROTO]
-            user = user_input[CONF_USER]
+            form_data[CONF_HOST] = user_input[CONF_HOST]
+            form_data[CONF_PORT] = user_input[CONF_PORT]
+            form_data[CONF_PROTO] = user_input[CONF_PROTO]
+            form_data[CONF_USER] = user_input[CONF_USER]
             pwrd = user_input[CONF_PASS]
 
-            try:
-                client = TesiraClient(host=host, port=port, proto=proto, username=user, password=pwrd)
-                await client.connect()
-                if client._conn is not None:
-                    try:
-                        device_info = await client.device_info()
-                        await client.disconnect()
-                        device_info = device_info["info"]
-                        _LOGGER.debug("Connectivity test successful: Device Info: %s", device_info)
-                        if existing_device_info:
-                            if device_info["serialNumber"] != existing_device_info.get("serialNumber") or device_info["deviceModel"] != existing_device_info.get("deviceModel") or device_info["deviceRevision"] != existing_device_info.get("deviceRevision"):
-                                _LOGGER.warning("Device info has changed from %s to %s. This may indicate that the connection parameters now point to a different Tesira device.", existing_device_info, device_info)
-                                raise TesiraTTPException.NotPermitted("Device info has changed. This may indicate that the connection parameters now point to a different Tesira device.")
-                    except TesiraTTPException.NotPermitted as e:
-                        _LOGGER.debug("Connectivity test succeeded but device info has changed: %s", e)
-                        errors["base"] = "different_device"
-                        await client.disconnect()
-                        return self.async_show_form(step_id="reconfigure", data_schema=_device_schema(defaults), errors=errors)
-                    except Exception as e:
-                        _LOGGER.debug("Connectivity test succeeded but failed to get device info: %s", e)
-                        errors["base"] = "device_info_failed"
-                        await client.disconnect()
-                        return self.async_show_form(step_id="reconfigure", data_schema=_device_schema(defaults), errors=errors)
-                else:
-                    raise ConnectionError("Failed to establish connection")
-            except TesiraClient.InvalidCredentials as e:
-                _LOGGER.debug("Connectivity test failed: %s", e)
-                errors["base"] = "invalid_credentials"
-                return self.async_show_form(step_id="reconfigure", data_schema=_device_schema(defaults), errors=errors)
-            except TesiraClient.AuthenticationUnsupportedError as e:
-                _LOGGER.debug("Connectivity test failed: %s", e)
-                errors["base"] = "unsupported_authentication"
-                return self.async_show_form(step_id="reconfigure", data_schema=_device_schema(defaults), errors=errors)
-            except Exception as e:
-                _LOGGER.debug("Connectivity test failed: %s", e)
-                errors["base"] = "cannot_connect"
-                return self.async_show_form(step_id="reconfigure", data_schema=_device_schema(defaults), errors=errors)
+            devices = self._devices
 
-            return self.async_update_reload_and_abort(entry, data_updates=user_input)
+            device_info, error = await self._connectivity_test(form_data[CONF_HOST], form_data[CONF_PORT], form_data[CONF_PROTO], form_data[CONF_USER], pwrd)
+            if error:
+                return self.async_show_form(step_id="edit_device", data_schema=_device_schema(form_data), errors={"base": error})
 
-        return self.async_show_form(step_id="reconfigure", data_schema=_device_schema(defaults), errors=errors)
+            device_id = gen_device_id(deviceModel=device_info["deviceModel"], deviceRevision=device_info["deviceRevision"], serialNumber=device_info["serialNumber"])
+            device = gen_device_dict(form_data[CONF_HOST], form_data[CONF_PORT], form_data[CONF_PROTO], form_data[CONF_USER], pwrd, device_info)
+
+            if device_id != edit_id:
+                _LOGGER.error("Device ID mismatch: expected %s but got %s. This should never happen.", edit_id, device_id)
+                form_errors["base"] = "different_device"
+                return self.async_show_form(step_id="edit_device", data_schema=_device_schema(form_data), errors=form_errors)
+
+            if device_id not in devices["items"]:
+                _LOGGER.error("Device ID %s not found in existing config. This should never happen.", device_id)
+                form_errors["base"] = "device_not_found"
+                return self.async_show_form(step_id="edit_device", data_schema=_device_schema(form_data), errors=form_errors)
+
+            devices["items"][device_id] = device
+            _LOGGER.debug("Updated existing device: %s", _redact_device(device))
+            return self.async_update_reload_and_abort(entry, data={CONF_DEVICES: devices}, reason="device_updated")
+
+        return self.async_show_form(step_id="edit_device", data_schema=_device_schema(defaults), errors=form_errors)
+
+    async def async_step_remove_device(self, user_input: dict[str, Any] | None = None) -> FlowResult:
+        form_errors: dict[str, str] = {}
+        entry = self.context.get("entry")
+        names = self._name_map()
+        if not names:
+            return self.async_abort(reason="no_devices")
+
+        schema = vol.Schema({vol.Required("select"): vol.In(list(names.keys()))})
+
+        if user_input is None:
+            return self.async_show_form(step_id="remove_device", data_schema=schema, errors={})
+
+        remove_id = names[user_input["select"]]
+        devices = self._devices
+        if devices["primary"] == remove_id:
+            _LOGGER.error("Cannot remove primary device, please change primary device first.")
+            form_errors["base"] = "cannot_remove_primary"
+            return self.async_show_form(step_id="remove_device", data_schema=schema, errors=form_errors)
+
+        if remove_id not in devices["items"]:
+            _LOGGER.error("Device ID %s not found in existing config. This should never happen.", remove_id)
+            form_errors["base"] = "device_not_found"
+            return self.async_show_form(step_id="remove_device", data_schema=schema, errors=form_errors)
+
+        devices["items"].pop(remove_id)
+        _LOGGER.debug("Removed device with ID %s", remove_id)
+        return self.async_update_reload_and_abort(entry, data={CONF_DEVICES: devices}, reason="device_removed")
+
+    async def async_step_change_primary(self, user_input: dict[str, Any] | None = None) -> FlowResult:
+        form_errors: dict[str, str] = {}
+        entry = self.context.get("entry")
+        names = self._name_map()
+        if not names:
+            return self.async_abort(reason="no_devices")
+
+        schema = vol.Schema({vol.Required("select"): vol.In(list(names.keys()))})
+
+        if user_input is None:
+            return self.async_show_form(step_id="change_primary", data_schema=schema, errors={})
+
+        new_primary_device = names[user_input["select"]]
+        devices = self._devices
+        if devices["primary"] == new_primary_device:
+            _LOGGER.debug("Selected device is already primary, no changes made.")
+            form_errors["base"] = "already_primary"
+            return self.async_show_form(step_id="change_primary", data_schema=schema, errors=form_errors)
+        if new_primary_device not in devices["items"]:
+            _LOGGER.error("Device ID %s not found in existing config. This should never happen.", new_primary_device)
+            form_errors["base"] = "device_not_found"
+            return self.async_show_form(step_id="change_primary", data_schema=schema, errors=form_errors)
+
+        devices["primary"] = new_primary_device
+        _LOGGER.debug("Changed primary device to ID %s", new_primary_device)
+        return self.async_update_reload_and_abort(entry, data={CONF_DEVICES: devices}, reason="primary_changed")
+
+    async def async_step_edit_hub_title(self, user_input: dict[str, Any] | None = None) -> FlowResult:
+        form_errors: dict[str, str] = {}
+
+        entry = self.context['entry']
+        defaults = {
+            CONF_HUB_TITLE: entry.title
+        }
+
+        if user_input is not None:
+            title = user_input[CONF_HUB_TITLE]
+
+            return self.async_update_reload_and_abort(entry, title=title)
+
+        return self.async_show_form(step_id="edit_hub_title", data_schema=_hub(defaults), errors=form_errors)
 
     @staticmethod
     def async_get_options_flow(config_entry: config_entries.ConfigEntry) -> config_entries.OptionsFlow:
@@ -235,19 +345,7 @@ class TesiraTtpOptionsFlow(config_entries.OptionsFlow):
     async def async_step_init(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         return self.async_show_menu(
             step_id="init",
-            menu_options=["devices", "entities"],
-        )
-
-    async def async_step_entities(self, user_input: dict[str, Any] | None = None) -> FlowResult:
-        return self.async_show_menu(
-            step_id="entities",
             menu_options=["add_entity", "select_entity", "remove_entity"],
-        )
-
-    async def async_step_devices(self, user_input: dict[str, Any] | None = None) -> FlowResult:
-        return self.async_show_menu(
-            step_id="devices",
-            menu_options=["add_device", "select_device", "remove_device"],
         )
 
     async def async_step_add_entity(self, user_input: dict[str, Any] | None = None) -> FlowResult:

--- a/custom_components/tesira_ttp/config_flow.py
+++ b/custom_components/tesira_ttp/config_flow.py
@@ -2,7 +2,7 @@
 # Filename: \custom_components\tesira_ttp\config_flow.py                                                               #
 # Repository: tesira_ttp                                                                                               #
 # Created Date: Thursday, March 19th 2026, 12:56:52 AM                                                                 #
-# Last Modified: Wednesday, April 8th 2026, 9:16:23 PM                                                                 #
+# Last Modified: Sunday, April 12th 2026, 10:09:23 PM                                                                  #
 # Original Author: Darnel Kumar                                                                                        #
 # Author Github: https://github.com/Darnel-K                                                                           #
 #                                                                                                                      #
@@ -35,27 +35,7 @@ from homeassistant.helpers.selector import selector
 from homeassistant.data_entry_flow import FlowResult
 import homeassistant.helpers.config_validation as cv
 
-from .const import (
-    DOMAIN,
-    CONF_HUB_TITLE,
-    CONF_HOST,
-    CONF_PORT,
-    CONF_PROTO,
-    CONF_USER,
-    CONF_PASS,
-    CONF_CONTROLS,
-    CONF_DEVICES,
-    CONF_CONTROL_NAME,
-    CONF_INSTANCE_TAG,
-    CONF_CHANNEL,
-    CONF_MIN_DB,
-    CONF_MAX_DB,
-    CONF_STEP_DB,
-    DEFAULT_CONTROL_NAME,
-    DEFAULT_DEVICES,
-    MODE_INIT,
-    MODE_RECONFIGURE
-)
+from .const import DOMAIN, DICT_KEYS, DEFAULTS, CONFIG_MODES
 from .tesira_client import TesiraClient
 from .util import gen_device_id, gen_device_dict, _redact_device, TesiraTTPException
 from .schemas import _device_schema, _control_schema, _hub
@@ -69,9 +49,9 @@ class TesiraTtpConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     def _devices(self) -> dict[str, Any]:
         entry = self.context.get("entry")
         if entry is None:
-            return copy.deepcopy(DEFAULT_DEVICES)
+            return copy.deepcopy(DEFAULTS["DEVICES"])
 
-        return copy.deepcopy(entry.data.get(CONF_DEVICES, DEFAULT_DEVICES))
+        return copy.deepcopy(entry.data.get(DICT_KEYS["DEVICES"], DEFAULTS["DEVICES"]))
 
     def _name_map(self) -> dict[str, str]:
         """Return a mapping of human-readable device names to device IDs."""
@@ -129,9 +109,9 @@ class TesiraTtpConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         form_data: dict[str, Any] = {}
 
         if user_input is not None:
-            form_data[CONF_HUB_TITLE] = user_input[CONF_HUB_TITLE]
+            form_data[DICT_KEYS["HUB_TITLE"]] = user_input[DICT_KEYS["HUB_TITLE"]]
 
-            self.context[CONF_HUB_TITLE] = form_data[CONF_HUB_TITLE]
+            self.context[DICT_KEYS["HUB_TITLE"]] = form_data[DICT_KEYS["HUB_TITLE"]]
             return self.async_show_form(step_id="add_device", data_schema=_device_schema(), errors={})
 
         return self.async_show_form(step_id="user", data_schema=_hub(form_data), errors=form_errors)
@@ -139,41 +119,41 @@ class TesiraTtpConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_add_device(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         form_errors: dict[str, str] = {}
         entry = self.context.get("entry")
-        mode = MODE_RECONFIGURE if entry else MODE_INIT
+        mode = CONFIG_MODES["RECONFIGURE"] if entry else CONFIG_MODES["INIT"]
         form_data: dict[str, Any] = {}
 
         if user_input is not None:
-            form_data[CONF_HOST] = user_input[CONF_HOST]
-            form_data[CONF_PORT] = user_input[CONF_PORT]
-            form_data[CONF_PROTO] = user_input[CONF_PROTO]
-            form_data[CONF_USER] = user_input[CONF_USER]
-            pwrd = user_input[CONF_PASS]
+            form_data[DICT_KEYS["HOST"]] = user_input[DICT_KEYS["HOST"]]
+            form_data[DICT_KEYS["PORT"]] = user_input[DICT_KEYS["PORT"]]
+            form_data[DICT_KEYS["PROTO"]] = user_input[DICT_KEYS["PROTO"]]
+            form_data[DICT_KEYS["USER"]] = user_input[DICT_KEYS["USER"]]
+            pwrd = user_input[DICT_KEYS["PASS"]]
 
             devices = self._devices
 
-            device_info, error = await self._connectivity_test(form_data[CONF_HOST], form_data[CONF_PORT], form_data[CONF_PROTO], form_data[CONF_USER], pwrd)
+            device_info, error = await self._connectivity_test(form_data[DICT_KEYS["HOST"]], form_data[DICT_KEYS["PORT"]], form_data[DICT_KEYS["PROTO"]], form_data[DICT_KEYS["USER"]], pwrd)
             if error:
                 return self.async_show_form(step_id="add_device", data_schema=_device_schema(form_data), errors={"base": error})
 
             device_id = gen_device_id(deviceModel=device_info["deviceModel"], deviceRevision=device_info["deviceRevision"], serialNumber=device_info["serialNumber"])
-            device = gen_device_dict(form_data[CONF_HOST], form_data[CONF_PORT], form_data[CONF_PROTO], form_data[CONF_USER], pwrd, device_info)
+            device = gen_device_dict(form_data[DICT_KEYS["HOST"]], form_data[DICT_KEYS["PORT"]], form_data[DICT_KEYS["PROTO"]], form_data[DICT_KEYS["USER"]], pwrd, device_info)
 
             if device_id in devices["items"]:
                 _LOGGER.debug("Device with ID %s already exists in config, skipping addition", device_id)
                 form_errors["base"] = "device_exists"
                 return self.async_show_form(step_id="add_device", data_schema=_device_schema(form_data), errors=form_errors)
 
-            if mode == MODE_INIT:
-                title: str = self.context.get(CONF_HUB_TITLE)
+            if mode == CONFIG_MODES["INIT"]:
+                title: str = self.context.get(DICT_KEYS["HUB_TITLE"])
                 devices["items"][device_id] = device
                 devices["primary"] = device_id
                 _LOGGER.debug("Added new device: %s", _redact_device(device))
-                return self.async_create_entry(title=title, data={CONF_DEVICES: devices})
+                return self.async_create_entry(title=title, data={DICT_KEYS["DEVICES"]: devices})
             else:
                 entry = self.context['entry']
                 devices["items"][device_id] = device
                 _LOGGER.debug("Added new device: %s", _redact_device(device))
-                return self.async_update_reload_and_abort(entry, data={CONF_DEVICES: devices}, reason="device_added")
+                return self.async_update_reload_and_abort(entry, data={DICT_KEYS["DEVICES"]: devices}, reason="device_added")
 
         return self.async_show_form(step_id="add_device", data_schema=_device_schema(), errors=form_errors)
 
@@ -215,20 +195,20 @@ class TesiraTtpConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         defaults = existing_device["connection_info"] if existing_device else {}
 
         if user_input is not None:
-            form_data[CONF_HOST] = user_input[CONF_HOST]
-            form_data[CONF_PORT] = user_input[CONF_PORT]
-            form_data[CONF_PROTO] = user_input[CONF_PROTO]
-            form_data[CONF_USER] = user_input[CONF_USER]
-            pwrd = user_input[CONF_PASS]
+            form_data[DICT_KEYS["HOST"]] = user_input[DICT_KEYS["HOST"]]
+            form_data[DICT_KEYS["PORT"]] = user_input[DICT_KEYS["PORT"]]
+            form_data[DICT_KEYS["PROTO"]] = user_input[DICT_KEYS["PROTO"]]
+            form_data[DICT_KEYS["USER"]] = user_input[DICT_KEYS["USER"]]
+            pwrd = user_input[DICT_KEYS["PASS"]]
 
             devices = self._devices
 
-            device_info, error = await self._connectivity_test(form_data[CONF_HOST], form_data[CONF_PORT], form_data[CONF_PROTO], form_data[CONF_USER], pwrd)
+            device_info, error = await self._connectivity_test(form_data[DICT_KEYS["HOST"]], form_data[DICT_KEYS["PORT"]], form_data[DICT_KEYS["PROTO"]], form_data[DICT_KEYS["USER"]], pwrd)
             if error:
                 return self.async_show_form(step_id="edit_device", data_schema=_device_schema(form_data), errors={"base": error})
 
             device_id = gen_device_id(deviceModel=device_info["deviceModel"], deviceRevision=device_info["deviceRevision"], serialNumber=device_info["serialNumber"])
-            device = gen_device_dict(form_data[CONF_HOST], form_data[CONF_PORT], form_data[CONF_PROTO], form_data[CONF_USER], pwrd, device_info)
+            device = gen_device_dict(form_data[DICT_KEYS["HOST"]], form_data[DICT_KEYS["PORT"]], form_data[DICT_KEYS["PROTO"]], form_data[DICT_KEYS["USER"]], pwrd, device_info)
 
             if device_id != edit_id:
                 _LOGGER.error("Device ID mismatch: expected %s but got %s. This should never happen.", edit_id, device_id)
@@ -242,7 +222,7 @@ class TesiraTtpConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
             devices["items"][device_id] = device
             _LOGGER.debug("Updated existing device: %s", _redact_device(device))
-            return self.async_update_reload_and_abort(entry, data={CONF_DEVICES: devices}, reason="device_updated")
+            return self.async_update_reload_and_abort(entry, data={DICT_KEYS["DEVICES"]: devices}, reason="device_updated")
 
         return self.async_show_form(step_id="edit_device", data_schema=_device_schema(defaults), errors=form_errors)
 
@@ -272,7 +252,7 @@ class TesiraTtpConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         devices["items"].pop(remove_id)
         _LOGGER.debug("Removed device with ID %s", remove_id)
-        return self.async_update_reload_and_abort(entry, data={CONF_DEVICES: devices}, reason="device_removed")
+        return self.async_update_reload_and_abort(entry, data={DICT_KEYS["DEVICES"]: devices}, reason="device_removed")
 
     async def async_step_change_primary(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         form_errors: dict[str, str] = {}
@@ -299,18 +279,18 @@ class TesiraTtpConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         devices["primary"] = new_primary_device
         _LOGGER.debug("Changed primary device to ID %s", new_primary_device)
-        return self.async_update_reload_and_abort(entry, data={CONF_DEVICES: devices}, reason="primary_changed")
+        return self.async_update_reload_and_abort(entry, data={DICT_KEYS["DEVICES"]: devices}, reason="primary_changed")
 
     async def async_step_edit_hub_title(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         form_errors: dict[str, str] = {}
 
         entry = self.context['entry']
         defaults = {
-            CONF_HUB_TITLE: entry.title
+            DICT_KEYS["HUB_TITLE"]: entry.title
         }
 
         if user_input is not None:
-            title = user_input[CONF_HUB_TITLE]
+            title = user_input[DICT_KEYS["HUB_TITLE"]]
 
             return self.async_update_reload_and_abort(entry, title=title)
 
@@ -328,14 +308,14 @@ class TesiraTtpOptionsFlow(config_entries.OptionsFlow):
 
     @property
     def _controls(self) -> list[dict[str, Any]]:
-        return list(self.config_entry.options.get(CONF_CONTROLS, []))
+        return list(self.config_entry.options.get(DICT_KEYS["CONTROLS"], []))
 
     def _label_map(self) -> dict[str, int]:
         labels: dict[str, int] = {}
         for i, c in enumerate(self._controls):
-            name = c.get(CONF_CONTROL_NAME, DEFAULT_CONTROL_NAME)
-            tag = c.get(CONF_INSTANCE_TAG, "?")
-            ch = c.get(CONF_CHANNEL, "?")
+            name = c.get(DICT_KEYS["CONTROL_NAME"], DEFAULTS["CONTROL_NAME"])
+            tag = c.get(DICT_KEYS["INSTANCE_TAG"], "?")
+            ch = c.get(DICT_KEYS["CHANNEL"], "?")
             label = f"{name} ({tag} ch{ch})"
             if label in labels:
                 label = f"{label} [{i}]"
@@ -355,15 +335,15 @@ class TesiraTtpOptionsFlow(config_entries.OptionsFlow):
         controls = self._controls
         controls.append(
             {
-                CONF_CONTROL_NAME: user_input[CONF_CONTROL_NAME],
-                CONF_INSTANCE_TAG: user_input[CONF_INSTANCE_TAG],
-                CONF_CHANNEL: user_input[CONF_CHANNEL],
-                CONF_MIN_DB: user_input[CONF_MIN_DB],
-                CONF_MAX_DB: user_input[CONF_MAX_DB],
-                CONF_STEP_DB: user_input[CONF_STEP_DB],
+                DICT_KEYS["CONTROL_NAME"]: user_input[DICT_KEYS["CONTROL_NAME"]],
+                DICT_KEYS["INSTANCE_TAG"]: user_input[DICT_KEYS["INSTANCE_TAG"]],
+                DICT_KEYS["CHANNEL"]: user_input[DICT_KEYS["CHANNEL"]],
+                DICT_KEYS["MIN_DB"]: user_input[DICT_KEYS["MIN_DB"]],
+                DICT_KEYS["MAX_DB"]: user_input[DICT_KEYS["MAX_DB"]],
+                DICT_KEYS["STEP_DB"]: user_input[DICT_KEYS["STEP_DB"]],
             }
         )
-        return self.async_create_entry(title="", data={CONF_CONTROLS: controls})
+        return self.async_create_entry(title="", data={DICT_KEYS["CONTROLS"]: controls})
 
     async def async_step_select_entity(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         labels = self._label_map()
@@ -388,15 +368,15 @@ class TesiraTtpOptionsFlow(config_entries.OptionsFlow):
 
         controls = self._controls
         controls[self._edit_index] = {
-            CONF_CONTROL_NAME: user_input[CONF_CONTROL_NAME],
-            CONF_INSTANCE_TAG: user_input[CONF_INSTANCE_TAG],
-            CONF_CHANNEL: user_input[CONF_CHANNEL],
-            CONF_MIN_DB: user_input[CONF_MIN_DB],
-            CONF_MAX_DB: user_input[CONF_MAX_DB],
-            CONF_STEP_DB: user_input[CONF_STEP_DB],
+            DICT_KEYS["CONTROL_NAME"]: user_input[DICT_KEYS["CONTROL_NAME"]],
+            DICT_KEYS["INSTANCE_TAG"]: user_input[DICT_KEYS["INSTANCE_TAG"]],
+            DICT_KEYS["CHANNEL"]: user_input[DICT_KEYS["CHANNEL"]],
+            DICT_KEYS["MIN_DB"]: user_input[DICT_KEYS["MIN_DB"]],
+            DICT_KEYS["MAX_DB"]: user_input[DICT_KEYS["MAX_DB"]],
+            DICT_KEYS["STEP_DB"]: user_input[DICT_KEYS["STEP_DB"]],
         }
         self._edit_index = None
-        return self.async_create_entry(title="", data={CONF_CONTROLS: controls})
+        return self.async_create_entry(title="", data={DICT_KEYS["CONTROLS"]: controls})
 
     async def async_step_remove_entity(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         labels = self._label_map()
@@ -411,4 +391,4 @@ class TesiraTtpOptionsFlow(config_entries.OptionsFlow):
         selected_indices = {labels[label] for label in selected_labels}
         controls = [c for i, c in enumerate(self._controls) if i not in selected_indices]
 
-        return self.async_create_entry(title="", data={CONF_CONTROLS: controls})
+        return self.async_create_entry(title="", data={DICT_KEYS["CONTROLS"]: controls})

--- a/custom_components/tesira_ttp/config_flow.py
+++ b/custom_components/tesira_ttp/config_flow.py
@@ -2,7 +2,7 @@
 # Filename: \custom_components\tesira_ttp\config_flow.py                                                               #
 # Repository: tesira_ttp                                                                                               #
 # Created Date: Thursday, March 19th 2026, 12:56:52 AM                                                                 #
-# Last Modified: Friday, April 3rd 2026, 9:55:19 PM                                                                    #
+# Last Modified: Saturday, April 4th 2026, 9:49:42 PM                                                                  #
 # Original Author: Darnel Kumar                                                                                        #
 # Author Github: https://github.com/Darnel-K                                                                           #
 #                                                                                                                      #
@@ -237,12 +237,24 @@ class TesiraTtpOptionsFlow(config_entries.OptionsFlow):
     async def async_step_init(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         return self.async_show_menu(
             step_id="init",
-            menu_options=["add", "edit", "remove"],
+            menu_options=["devices", "entities"],
         )
 
-    async def async_step_add(self, user_input: dict[str, Any] | None = None) -> FlowResult:
+    async def async_step_entities(self, user_input: dict[str, Any] | None = None) -> FlowResult:
+        return self.async_show_menu(
+            step_id="entities",
+            menu_options=["add_entity", "select_entity", "remove_entity"],
+        )
+
+    async def async_step_devices(self, user_input: dict[str, Any] | None = None) -> FlowResult:
+        return self.async_show_menu(
+            step_id="devices",
+            menu_options=["add_device", "select_device", "remove_device"],
+        )
+
+    async def async_step_add_entity(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         if user_input is None:
-            return self.async_show_form(step_id="add", data_schema=_control_schema(), errors={})
+            return self.async_show_form(step_id="add_entity", data_schema=_control_schema(), errors={})
 
         controls = self._controls
         controls.append(
@@ -257,26 +269,26 @@ class TesiraTtpOptionsFlow(config_entries.OptionsFlow):
         )
         return self.async_create_entry(title="", data={CONF_CONTROLS: controls})
 
-    async def async_step_edit(self, user_input: dict[str, Any] | None = None) -> FlowResult:
+    async def async_step_select_entity(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         labels = self._label_map()
         if not labels:
             return self.async_abort(reason="no_controls")
 
         if user_input is None:
             schema = vol.Schema({vol.Required("which"): vol.In(list(labels.keys()))})
-            return self.async_show_form(step_id="edit", data_schema=schema, errors={})
+            return self.async_show_form(step_id="select_entity", data_schema=schema, errors={})
 
         self._edit_index = labels[user_input["which"]]
         defaults = self._controls[self._edit_index]
-        return self.async_show_form(step_id="edit_control", data_schema=_control_schema(defaults), errors={})
+        return self.async_show_form(step_id="edit_entity", data_schema=_control_schema(defaults), errors={})
 
-    async def async_step_edit_control(self, user_input: dict[str, Any] | None = None) -> FlowResult:
+    async def async_step_edit_entity(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         if self._edit_index is None:
             return self.async_abort(reason="unknown")
 
         if user_input is None:
             defaults = self._controls[self._edit_index]
-            return self.async_show_form(step_id="edit_control", data_schema=_control_schema(defaults), errors={})
+            return self.async_show_form(step_id="edit_entity", data_schema=_control_schema(defaults), errors={})
 
         controls = self._controls
         controls[self._edit_index] = {
@@ -290,14 +302,14 @@ class TesiraTtpOptionsFlow(config_entries.OptionsFlow):
         self._edit_index = None
         return self.async_create_entry(title="", data={CONF_CONTROLS: controls})
 
-    async def async_step_remove(self, user_input: dict[str, Any] | None = None) -> FlowResult:
+    async def async_step_remove_entity(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         labels = self._label_map()
         if not labels:
             return self.async_abort(reason="no_controls")
 
         if user_input is None:
             schema = vol.Schema({vol.Required("remove"): cv.multi_select(labels)})
-            return self.async_show_form(step_id="remove", data_schema=schema, errors={})
+            return self.async_show_form(step_id="remove_entity", data_schema=schema, errors={})
 
         selected_labels = set(user_input["remove"])
         selected_indices = {labels[label] for label in selected_labels}

--- a/custom_components/tesira_ttp/config_flow.py
+++ b/custom_components/tesira_ttp/config_flow.py
@@ -2,7 +2,7 @@
 # Filename: \custom_components\tesira_ttp\config_flow.py                                                               #
 # Repository: tesira_ttp                                                                                               #
 # Created Date: Thursday, March 19th 2026, 12:56:52 AM                                                                 #
-# Last Modified: Sunday, April 5th 2026, 6:59:30 PM                                                                    #
+# Last Modified: Sunday, April 5th 2026, 9:19:42 PM                                                                    #
 # Original Author: Darnel Kumar                                                                                        #
 # Author Github: https://github.com/Darnel-K                                                                           #
 #                                                                                                                      #
@@ -61,8 +61,8 @@ from .const import (
     DEFAULT_STEP_DB
 )
 from .tesira_client import TesiraClient
-from .util import schema_with_defaults, gen_hub_key, TesiraTTPException
-from .schemas import _device_schema
+from .util import gen_hub_key, TesiraTTPException
+from .schemas import _device_schema, _control_schema
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -83,31 +83,18 @@ STEP_USER_SCHEMA = vol.Schema(
     }
 )
 
-def _control_schema(defaults: dict[str, Any] | None = None) -> vol.Schema:
-    d = defaults or {}
-    return vol.Schema(
-        {
-            vol.Optional(CONF_CONTROL_NAME, default=d.get(CONF_CONTROL_NAME, DEFAULT_CONTROL_NAME)): cv.string,
-            vol.Required(CONF_INSTANCE_TAG, default=d.get(CONF_INSTANCE_TAG, "volume")): cv.string,
-            vol.Optional(CONF_CHANNEL, default=int(d.get(CONF_CHANNEL, DEFAULT_CHANNEL))): vol.Coerce(int),
-            vol.Optional(CONF_MIN_DB, default=float(d.get(CONF_MIN_DB, DEFAULT_MIN_DB))): vol.Coerce(float),
-            vol.Optional(CONF_MAX_DB, default=float(d.get(CONF_MAX_DB, DEFAULT_MAX_DB))): vol.Coerce(float),
-            vol.Optional(CONF_STEP_DB, default=float(d.get(CONF_STEP_DB, DEFAULT_STEP_DB))): vol.Coerce(float),
-        }
-    )
-
 class TesiraTtpConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 1
 
     @property
     def _primary_device(self) -> dict[str, Any]:
         items = dict(self.config_entry.options.get(CONF_ITEMS, {}))
-        return (items.get("devices")).get("primary", {})
+        return (items.get("devices", {})).get("primary", {})
 
     @property
     def _secondary_devices(self) -> list[dict[str, Any]]:
         items = dict(self.config_entry.options.get(CONF_ITEMS, {}))
-        return (items.get("devices")).get("secondary", [])
+        return (items.get("devices", [])).get("secondary", [])
 
     async def async_step_user(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         errors: dict[str, str] = {}
@@ -137,26 +124,26 @@ class TesiraTtpConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         _LOGGER.debug("Connectivity test succeeded but failed to get device info: %s", e)
                         errors["base"] = "device_info_failed"
                         await client.disconnect()
-                        return self.async_show_form(step_id="user", data_schema=STEP_USER_SCHEMA, errors=errors)
+                        return self.async_show_form(step_id="user", data_schema=_device_schema(), errors=errors)
                 else:
                     raise ConnectionError("Failed to establish connection")
             except TesiraClient.InvalidCredentials as e:
                 _LOGGER.debug("Connectivity test failed: %s", e)
                 errors["base"] = "invalid_credentials"
-                return self.async_show_form(step_id="user", data_schema=STEP_USER_SCHEMA, errors=errors)
+                return self.async_show_form(step_id="user", data_schema=_device_schema(), errors=errors)
             except TesiraClient.AuthenticationUnsupportedError as e:
                 _LOGGER.debug("Connectivity test failed: %s", e)
                 errors["base"] = "unsupported_authentication"
-                return self.async_show_form(step_id="user", data_schema=STEP_USER_SCHEMA, errors=errors)
+                return self.async_show_form(step_id="user", data_schema=_device_schema(), errors=errors)
             except Exception as e:
                 _LOGGER.debug("Connectivity test failed: %s", e)
                 errors["base"] = "cannot_connect"
-                return self.async_show_form(step_id="user", data_schema=STEP_USER_SCHEMA, errors=errors)
+                return self.async_show_form(step_id="user", data_schema=_device_schema(), errors=errors)
 
             title = f"Biamp - {device_info['deviceModel']} - {device_info['serialNumber']} - {host}:{port}"
             return self.async_create_entry(title=title, data={CONF_IP: host, CONF_PORT: port, CONF_PROTO: proto, CONF_USER: user, CONF_PASS: pwrd, CONF_DEVICE_INFO: device_info})
 
-        return self.async_show_form(step_id="user", data_schema=STEP_USER_SCHEMA, errors=errors)
+        return self.async_show_form(step_id="user", data_schema=_device_schema(), errors=errors)
 
     async def async_step_reconfigure(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         errors: dict[str, str] = {}
@@ -168,7 +155,6 @@ class TesiraTtpConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             CONF_PROTO: entry.data.get(CONF_PROTO),
             CONF_USER: entry.data.get(CONF_USER)
         }
-        schema = schema_with_defaults(STEP_USER_SCHEMA, defaults)
         existing_device_info = entry.data.get(CONF_DEVICE_INFO)
 
         if user_input is not None:
@@ -195,30 +181,30 @@ class TesiraTtpConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         _LOGGER.debug("Connectivity test succeeded but device info has changed: %s", e)
                         errors["base"] = "different_device"
                         await client.disconnect()
-                        return self.async_show_form(step_id="reconfigure", data_schema=schema, errors=errors)
+                        return self.async_show_form(step_id="reconfigure", data_schema=_device_schema(defaults), errors=errors)
                     except Exception as e:
                         _LOGGER.debug("Connectivity test succeeded but failed to get device info: %s", e)
                         errors["base"] = "device_info_failed"
                         await client.disconnect()
-                        return self.async_show_form(step_id="reconfigure", data_schema=schema, errors=errors)
+                        return self.async_show_form(step_id="reconfigure", data_schema=_device_schema(defaults), errors=errors)
                 else:
                     raise ConnectionError("Failed to establish connection")
             except TesiraClient.InvalidCredentials as e:
                 _LOGGER.debug("Connectivity test failed: %s", e)
                 errors["base"] = "invalid_credentials"
-                return self.async_show_form(step_id="reconfigure", data_schema=schema, errors=errors)
+                return self.async_show_form(step_id="reconfigure", data_schema=_device_schema(defaults), errors=errors)
             except TesiraClient.AuthenticationUnsupportedError as e:
                 _LOGGER.debug("Connectivity test failed: %s", e)
                 errors["base"] = "unsupported_authentication"
-                return self.async_show_form(step_id="reconfigure", data_schema=schema, errors=errors)
+                return self.async_show_form(step_id="reconfigure", data_schema=_device_schema(defaults), errors=errors)
             except Exception as e:
                 _LOGGER.debug("Connectivity test failed: %s", e)
                 errors["base"] = "cannot_connect"
-                return self.async_show_form(step_id="reconfigure", data_schema=schema, errors=errors)
+                return self.async_show_form(step_id="reconfigure", data_schema=_device_schema(defaults), errors=errors)
 
             return self.async_update_reload_and_abort(entry, data_updates=user_input)
 
-        return self.async_show_form(step_id="reconfigure", data_schema=schema, errors=errors)
+        return self.async_show_form(step_id="reconfigure", data_schema=_device_schema(defaults), errors=errors)
 
     @staticmethod
     def async_get_options_flow(config_entry: config_entries.ConfigEntry) -> config_entries.OptionsFlow:

--- a/custom_components/tesira_ttp/const.py
+++ b/custom_components/tesira_ttp/const.py
@@ -2,7 +2,7 @@
 # Filename: \custom_components\tesira_ttp\const.py                                                                     #
 # Repository: tesira_ttp                                                                                               #
 # Created Date: Thursday, March 19th 2026, 12:56:52 AM                                                                 #
-# Last Modified: Tuesday, April 7th 2026, 10:02:06 PM                                                                  #
+# Last Modified: Sunday, April 12th 2026, 10:05:47 PM                                                                  #
 # Original Author: Darnel Kumar                                                                                        #
 # Author Github: https://github.com/Darnel-K                                                                           #
 #                                                                                                                      #
@@ -29,46 +29,52 @@ from homeassistant.const import Platform
 DOMAIN = "tesira_ttp"
 PLATFORMS: list[Platform] = [Platform.MEDIA_PLAYER, Platform.BINARY_SENSOR]
 
-CONF_HUB_TITLE = "hub_title"
-CONF_HOST = "host"
-CONF_PORT = "port"
-CONF_PROTO = "protocol"
-CONF_USER = "username"
-CONF_PASS = "password"
-CONF_DEVICE_INFO = "device_info"
+DICT_KEYS = {
+    "DATA_HUBS": "hubs",
+    "DATA_ENTRY_HUBKEY": "entry_hubkey",
+    "HUB_TITLE": "hub_title",
+    "HOST": "host",
+    "PORT": "port",
+    "PROTO": "protocol",
+    "USER": "username",
+    "PASS": "password",
+    "DEVICE_INFO": "device_info",
+    "CONTROLS": "controls",
+    "DEVICES": "devices",
+    "ENTITIES": "entities",
+    "CONTROL_NAME": "name",
+    "INSTANCE_TAG": "instance_tag",
+    "CHANNEL": "channel",
+    "MIN_DB": "min_db",
+    "MAX_DB": "max_db",
+    "STEP_DB": "step_db"
+}
 
-# Controls live in options as a list of dicts
-CONF_CONTROLS = "controls"
+CONFIG_MODES = {
+    "INIT": "init",
+    "RECONFIGURE": "reconfigure"
+}
 
-CONF_DEVICES = "devices"
-CONF_ENTITIES = "entities"
-
-CONF_CONTROL_NAME = "name"
-CONF_INSTANCE_TAG = "instance_tag"
-CONF_CHANNEL = "channel"
-CONF_MIN_DB = "min_db"
-CONF_MAX_DB = "max_db"
-CONF_STEP_DB = "step_db"
-
-DEFAULT_IP = "0.0.0.0"
-DEFAULT_PORT = 22
-DEFAULT_PROTO = "ssh"
-DEFAULT_USER = "default"
-DEFAULT_PASS = ""
-DEFAULT_CONTROL_NAME = "Tesira Volume"
-DEFAULT_CHANNEL = 1
-DEFAULT_MIN_DB = -100.0
-DEFAULT_MAX_DB = 12.0
-DEFAULT_STEP_DB = 0.5
 DEFAULT_DEVICES = {
     "items": {},
     "primary": None
 }
+
 DEFAULT_ENTITIES = {
-    "entity_type": {
-        "block_type": []
-    }
+    "block_type": []
 }
 
-MODE_INIT = "init"
-MODE_RECONFIGURE = "reconfigure"
+DEFAULTS = {
+    "HOST": "0.0.0.0",
+    "PORT": 22,
+    "PROTO": "ssh",
+    "USER": "default",
+    "PASS": "",
+    "CONTROL_NAME": "Tesira Volume",
+    "CHANNEL": 1,
+    "MIN_DB": -100.0,
+    "MAX_DB": 12.0,
+    "STEP_DB": 0.5,
+    "DEVICES": DEFAULT_DEVICES,
+    "ENTITIES": DEFAULT_ENTITIES
+}

--- a/custom_components/tesira_ttp/const.py
+++ b/custom_components/tesira_ttp/const.py
@@ -2,7 +2,7 @@
 # Filename: \custom_components\tesira_ttp\const.py                                                                     #
 # Repository: tesira_ttp                                                                                               #
 # Created Date: Thursday, March 19th 2026, 12:56:52 AM                                                                 #
-# Last Modified: Sunday, April 5th 2026, 6:46:41 PM                                                                    #
+# Last Modified: Tuesday, April 7th 2026, 10:02:06 PM                                                                  #
 # Original Author: Darnel Kumar                                                                                        #
 # Author Github: https://github.com/Darnel-K                                                                           #
 #                                                                                                                      #
@@ -29,7 +29,8 @@ from homeassistant.const import Platform
 DOMAIN = "tesira_ttp"
 PLATFORMS: list[Platform] = [Platform.MEDIA_PLAYER, Platform.BINARY_SENSOR]
 
-CONF_IP = "host"
+CONF_HUB_TITLE = "hub_title"
+CONF_HOST = "host"
 CONF_PORT = "port"
 CONF_PROTO = "protocol"
 CONF_USER = "username"
@@ -38,7 +39,9 @@ CONF_DEVICE_INFO = "device_info"
 
 # Controls live in options as a list of dicts
 CONF_CONTROLS = "controls"
-CONF_ITEMS = "items"
+
+CONF_DEVICES = "devices"
+CONF_ENTITIES = "entities"
 
 CONF_CONTROL_NAME = "name"
 CONF_INSTANCE_TAG = "instance_tag"
@@ -57,3 +60,15 @@ DEFAULT_CHANNEL = 1
 DEFAULT_MIN_DB = -100.0
 DEFAULT_MAX_DB = 12.0
 DEFAULT_STEP_DB = 0.5
+DEFAULT_DEVICES = {
+    "items": {},
+    "primary": None
+}
+DEFAULT_ENTITIES = {
+    "entity_type": {
+        "block_type": []
+    }
+}
+
+MODE_INIT = "init"
+MODE_RECONFIGURE = "reconfigure"

--- a/custom_components/tesira_ttp/hub.py
+++ b/custom_components/tesira_ttp/hub.py
@@ -1,8 +1,8 @@
 # #################################################################################################################### #
 # Filename: \custom_components\tesira_ttp\hub.py                                                                       #
 # Repository: tesira_ttp                                                                                               #
-# Created Date: Friday, April 3rd 2026, 11:30:15 PM                                                                    #
-# Last Modified: Saturday, April 4th 2026, 2:25:59 PM                                                                  #
+# Created Date: Thursday, March 19th 2026, 12:56:52 AM                                                                 #
+# Last Modified: Tuesday, April 7th 2026, 11:07:07 PM                                                                  #
 # Original Author: Darnel Kumar                                                                                        #
 # Author Github: https://github.com/Darnel-K                                                                           #
 #                                                                                                                      #
@@ -28,7 +28,7 @@ import asyncio
 import logging
 
 from .tesira_client import TesiraClient
-from .util import gen_hub_key
+# from .util import gen_hub_key
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -71,11 +71,11 @@ class TesiraHub:
         )
         self._lock = asyncio.Lock()
 
-    @property
-    async def key(self) -> str:
-        device_info = await self.client.device_info()
-        device_info = device_info["info"]
-        return gen_hub_key(deviceModel=device_info["deviceModel"], deviceRevision=device_info["deviceRevision"], serialNumber=device_info["serialNumber"])
+    # @property
+    # async def key(self) -> str:
+    #     device_info = await self.client.device_info()
+    #     device_info = device_info["info"]
+    #     return gen_hub_key(deviceModel=device_info["deviceModel"], deviceRevision=device_info["deviceRevision"], serialNumber=device_info["serialNumber"])
 
     @property
     def is_connected(self) -> bool:

--- a/custom_components/tesira_ttp/manifest.json
+++ b/custom_components/tesira_ttp/manifest.json
@@ -18,5 +18,5 @@
         "asyncssh>=2.22.0",
         "prompt_toolkit>=3.0.52"
     ],
-    "version": "0.10.1"
+    "version": "0.11.0"
 }

--- a/custom_components/tesira_ttp/manifest.json
+++ b/custom_components/tesira_ttp/manifest.json
@@ -18,5 +18,5 @@
         "asyncssh>=2.22.0",
         "prompt_toolkit>=3.0.52"
     ],
-    "version": "0.11.0"
+    "version": "0.11.4"
 }

--- a/custom_components/tesira_ttp/media_player.py
+++ b/custom_components/tesira_ttp/media_player.py
@@ -2,7 +2,7 @@
 # Filename: \custom_components\tesira_ttp\media_player.py                                                              #
 # Repository: tesira_ttp                                                                                               #
 # Created Date: Thursday, March 19th 2026, 12:56:52 AM                                                                 #
-# Last Modified: Sunday, April 12th 2026, 10:09:23 PM                                                                  #
+# Last Modified: Sunday, April 12th 2026, 11:14:39 PM                                                                  #
 # Original Author: Darnel Kumar                                                                                        #
 # Author Github: https://github.com/Darnel-K                                                                           #
 #                                                                                                                      #
@@ -55,7 +55,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     # port = entry.data[CONF_PORT]
     # device_info = entry.data[CONF_DEVICE_INFO]
     hubkey = entry.entry_id
-    hub: TesiraHub = hass.data[DOMAIN][DICT_KEYS["HUBS"]][hubkey]
+    hub: TesiraHub = hass.data[DOMAIN][DICT_KEYS["DATA_HUBS"]][hubkey]
 
     controls: list[dict[str, Any]] = list(entry.options.get(DICT_KEYS["CONTROLS"], []))
 

--- a/custom_components/tesira_ttp/media_player.py
+++ b/custom_components/tesira_ttp/media_player.py
@@ -2,7 +2,7 @@
 # Filename: \custom_components\tesira_ttp\media_player.py                                                              #
 # Repository: tesira_ttp                                                                                               #
 # Created Date: Thursday, March 19th 2026, 12:56:52 AM                                                                 #
-# Last Modified: Friday, April 3rd 2026, 11:24:14 PM                                                                   #
+# Last Modified: Wednesday, April 8th 2026, 10:06:46 PM                                                                #
 # Original Author: Darnel Kumar                                                                                        #
 # Author Github: https://github.com/Darnel-K                                                                           #
 #                                                                                                                      #
@@ -42,8 +42,6 @@ from .const import (
     CONF_MIN_DB,
     CONF_MAX_DB,
     CONF_STEP_DB,
-    CONF_IP,
-    CONF_PORT,
     CONF_DEVICE_INFO,
     DEFAULT_CONTROL_NAME,
     DEFAULT_CHANNEL,
@@ -52,7 +50,6 @@ from .const import (
     DEFAULT_STEP_DB,
 )
 from .hub import TesiraHub
-from .util import gen_hub_key
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -70,10 +67,10 @@ def level01_to_db(level01: float, min_db: float, max_db: float) -> float:
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities) -> None:
     # Find shared hub by host:port
-    host = entry.data[CONF_IP]
-    port = entry.data[CONF_PORT]
-    device_info = entry.data[CONF_DEVICE_INFO]
-    hubkey = gen_hub_key(deviceModel=device_info.get("deviceModel"), deviceRevision=device_info.get("deviceRevision"), serialNumber=device_info.get("serialNumber"))
+    # host = entry.data[CONF_HOST]
+    # port = entry.data[CONF_PORT]
+    # device_info = entry.data[CONF_DEVICE_INFO]
+    hubkey = entry.entry_id
     hub: TesiraHub = hass.data[DOMAIN]["hubs"][hubkey]
 
     controls: list[dict[str, Any]] = list(entry.options.get(CONF_CONTROLS, []))
@@ -86,7 +83,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
         min_db = float(c.get(CONF_MIN_DB, DEFAULT_MIN_DB))
         max_db = float(c.get(CONF_MAX_DB, DEFAULT_MAX_DB))
         step_db = float(c.get(CONF_STEP_DB, DEFAULT_STEP_DB))
-        entities.append(TesiraVolumeMediaPlayer(hub, hubkey, host, port, name, tag, ch, min_db, max_db, step_db))
+        entities.append(TesiraVolumeMediaPlayer(hub, hubkey, name, tag, ch, min_db, max_db, step_db))
 
     async_add_entities(entities, update_before_add=True)
 
@@ -97,8 +94,6 @@ class TesiraVolumeMediaPlayer(MediaPlayerEntity):
         self,
         hub: TesiraHub,
         hubkey: str,
-        host: str,
-        port: int,
         name: str,
         instance_tag: str,
         channel: int,
@@ -108,8 +103,6 @@ class TesiraVolumeMediaPlayer(MediaPlayerEntity):
     ) -> None:
         self._hub = hub
         self._hubkey = hubkey
-        self._host = host
-        self._port = port
         self._tag = instance_tag
         self._ch = channel
         self._min_db = min_db
@@ -117,7 +110,7 @@ class TesiraVolumeMediaPlayer(MediaPlayerEntity):
         self._step_db = step_db
 
         self._attr_name = name
-        self._attr_unique_id = f"tesira_ttp_{host}_{port}_{self._tag}_{self._ch}".lower()
+        self._attr_unique_id = f"tesira_ttp_{self._hubkey}_{self._tag}_{self._ch}".lower()
 
         self._attr_supported_features = (
             MediaPlayerEntityFeature.VOLUME_SET
@@ -130,12 +123,6 @@ class TesiraVolumeMediaPlayer(MediaPlayerEntity):
 
         self._level_db: float | None = None
         self._muted: bool | None = None
-
-    @property
-    def device_info(self):
-        return {
-            "identifiers": {(DOMAIN, self._hubkey)}
-        }
 
     @property
     def volume_level(self) -> float | None:
@@ -168,7 +155,7 @@ class TesiraVolumeMediaPlayer(MediaPlayerEntity):
                 pass
 
         except Exception as e:
-            _LOGGER.debug("Update failed for %s/%s ch %s: %s", self._host, self._tag, self._ch, e)
+            _LOGGER.debug("Update failed for %s/%s ch %s: %s", self._hubkey, self._tag, self._ch, e)
             self._attr_available = False
             self._attr_state = MediaPlayerState.UNAVAILABLE
 

--- a/custom_components/tesira_ttp/media_player.py
+++ b/custom_components/tesira_ttp/media_player.py
@@ -2,7 +2,7 @@
 # Filename: \custom_components\tesira_ttp\media_player.py                                                              #
 # Repository: tesira_ttp                                                                                               #
 # Created Date: Thursday, March 19th 2026, 12:56:52 AM                                                                 #
-# Last Modified: Wednesday, April 8th 2026, 10:06:46 PM                                                                #
+# Last Modified: Sunday, April 12th 2026, 10:09:23 PM                                                                  #
 # Original Author: Darnel Kumar                                                                                        #
 # Author Github: https://github.com/Darnel-K                                                                           #
 #                                                                                                                      #
@@ -31,24 +31,8 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.components.media_player import MediaPlayerEntity
 from homeassistant.components.media_player.const import MediaPlayerEntityFeature, MediaPlayerState
-from homeassistant.util import slugify
 
-from .const import (
-    DOMAIN,
-    CONF_CONTROLS,
-    CONF_CONTROL_NAME,
-    CONF_INSTANCE_TAG,
-    CONF_CHANNEL,
-    CONF_MIN_DB,
-    CONF_MAX_DB,
-    CONF_STEP_DB,
-    CONF_DEVICE_INFO,
-    DEFAULT_CONTROL_NAME,
-    DEFAULT_CHANNEL,
-    DEFAULT_MIN_DB,
-    DEFAULT_MAX_DB,
-    DEFAULT_STEP_DB,
-)
+from .const import DOMAIN, DICT_KEYS, DEFAULTS
 from .hub import TesiraHub
 
 _LOGGER = logging.getLogger(__name__)
@@ -71,18 +55,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     # port = entry.data[CONF_PORT]
     # device_info = entry.data[CONF_DEVICE_INFO]
     hubkey = entry.entry_id
-    hub: TesiraHub = hass.data[DOMAIN]["hubs"][hubkey]
+    hub: TesiraHub = hass.data[DOMAIN][DICT_KEYS["HUBS"]][hubkey]
 
-    controls: list[dict[str, Any]] = list(entry.options.get(CONF_CONTROLS, []))
+    controls: list[dict[str, Any]] = list(entry.options.get(DICT_KEYS["CONTROLS"], []))
 
     entities: list[TesiraVolumeMediaPlayer] = []
     for c in controls:
-        name = c.get(CONF_CONTROL_NAME, DEFAULT_CONTROL_NAME)
-        tag = c[CONF_INSTANCE_TAG]
-        ch = int(c.get(CONF_CHANNEL, DEFAULT_CHANNEL))
-        min_db = float(c.get(CONF_MIN_DB, DEFAULT_MIN_DB))
-        max_db = float(c.get(CONF_MAX_DB, DEFAULT_MAX_DB))
-        step_db = float(c.get(CONF_STEP_DB, DEFAULT_STEP_DB))
+        name = c.get(DICT_KEYS["CONTROL_NAME"], DEFAULTS["CONTROL_NAME"])
+        tag = c[DICT_KEYS["INSTANCE_TAG"]]
+        ch = int(c.get(DICT_KEYS["CHANNEL"], DEFAULTS["CHANNEL"]))
+        min_db = float(c.get(DICT_KEYS["MIN_DB"], DEFAULTS["MIN_DB"]))
+        max_db = float(c.get(DICT_KEYS["MAX_DB"], DEFAULTS["MAX_DB"]))
+        step_db = float(c.get(DICT_KEYS["STEP_DB"], DEFAULTS["STEP_DB"]))
         entities.append(TesiraVolumeMediaPlayer(hub, hubkey, name, tag, ch, min_db, max_db, step_db))
 
     async_add_entities(entities, update_before_add=True)

--- a/custom_components/tesira_ttp/schemas.py
+++ b/custom_components/tesira_ttp/schemas.py
@@ -2,7 +2,7 @@
 # Filename: \custom_components\tesira_ttp\schemas.py                                                                   #
 # Repository: tesira_ttp                                                                                               #
 # Created Date: Thursday, March 19th 2026, 12:56:52 AM                                                                 #
-# Last Modified: Sunday, April 5th 2026, 6:46:41 PM                                                                    #
+# Last Modified: Sunday, April 5th 2026, 9:10:10 PM                                                                    #
 # Original Author: Darnel Kumar                                                                                        #
 # Author Github: https://github.com/Darnel-K                                                                           #
 #                                                                                                                      #
@@ -42,7 +42,18 @@ from .const import (
     DEFAULT_PORT,
     DEFAULT_PROTO,
     DEFAULT_USER,
-    DEFAULT_PASS
+    DEFAULT_PASS,
+    CONF_CONTROL_NAME,
+    CONF_INSTANCE_TAG,
+    CONF_CHANNEL,
+    CONF_MIN_DB,
+    CONF_MAX_DB,
+    CONF_STEP_DB,
+    DEFAULT_CONTROL_NAME,
+    DEFAULT_CHANNEL,
+    DEFAULT_MIN_DB,
+    DEFAULT_MAX_DB,
+    DEFAULT_STEP_DB
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -63,5 +74,18 @@ def _device_schema(defaults: dict[str, Any] | None = None) -> vol.Schema:
             }),
             vol.Optional(CONF_USER, default=d.get(CONF_USER, DEFAULT_USER)): cv.string,
             vol.Optional(CONF_PASS, default=d.get(CONF_PASS, DEFAULT_PASS)): cv.string
+        }
+    )
+
+def _control_schema(defaults: dict[str, Any] | None = None) -> vol.Schema:
+    d = defaults or {}
+    return vol.Schema(
+        {
+            vol.Optional(CONF_CONTROL_NAME, default=d.get(CONF_CONTROL_NAME, DEFAULT_CONTROL_NAME)): cv.string,
+            vol.Required(CONF_INSTANCE_TAG, default=d.get(CONF_INSTANCE_TAG, "volume")): cv.string,
+            vol.Optional(CONF_CHANNEL, default=int(d.get(CONF_CHANNEL, DEFAULT_CHANNEL))): vol.Coerce(int),
+            vol.Optional(CONF_MIN_DB, default=float(d.get(CONF_MIN_DB, DEFAULT_MIN_DB))): vol.Coerce(float),
+            vol.Optional(CONF_MAX_DB, default=float(d.get(CONF_MAX_DB, DEFAULT_MAX_DB))): vol.Coerce(float),
+            vol.Optional(CONF_STEP_DB, default=float(d.get(CONF_STEP_DB, DEFAULT_STEP_DB))): vol.Coerce(float),
         }
     )

--- a/custom_components/tesira_ttp/schemas.py
+++ b/custom_components/tesira_ttp/schemas.py
@@ -1,5 +1,5 @@
 # #################################################################################################################### #
-# Filename: \custom_components\tesira_ttp\const.py                                                                     #
+# Filename: \custom_components\tesira_ttp\schemas.py                                                                   #
 # Repository: tesira_ttp                                                                                               #
 # Created Date: Thursday, March 19th 2026, 12:56:52 AM                                                                 #
 # Last Modified: Sunday, April 5th 2026, 6:46:41 PM                                                                    #
@@ -22,38 +22,46 @@
 # You should have received a copy of the GNU Affero General Public License                                             #
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.                                               #
 # #################################################################################################################### #
+
 from __future__ import annotations
 
-from homeassistant.const import Platform
+import logging
+import voluptuous as vol
+import homeassistant.helpers.config_validation as cv
 
-DOMAIN = "tesira_ttp"
-PLATFORMS: list[Platform] = [Platform.MEDIA_PLAYER, Platform.BINARY_SENSOR]
+from typing import Any
+from homeassistant.helpers.selector import selector
+from .const import (
+    DOMAIN,
+    CONF_IP,
+    CONF_PORT,
+    CONF_PROTO,
+    CONF_USER,
+    CONF_PASS,
+    DEFAULT_IP,
+    DEFAULT_PORT,
+    DEFAULT_PROTO,
+    DEFAULT_USER,
+    DEFAULT_PASS
+)
 
-CONF_IP = "host"
-CONF_PORT = "port"
-CONF_PROTO = "protocol"
-CONF_USER = "username"
-CONF_PASS = "password"
-CONF_DEVICE_INFO = "device_info"
+_LOGGER = logging.getLogger(__name__)
 
-# Controls live in options as a list of dicts
-CONF_CONTROLS = "controls"
-CONF_ITEMS = "items"
-
-CONF_CONTROL_NAME = "name"
-CONF_INSTANCE_TAG = "instance_tag"
-CONF_CHANNEL = "channel"
-CONF_MIN_DB = "min_db"
-CONF_MAX_DB = "max_db"
-CONF_STEP_DB = "step_db"
-
-DEFAULT_IP = "0.0.0.0"
-DEFAULT_PORT = 22
-DEFAULT_PROTO = "ssh"
-DEFAULT_USER = "default"
-DEFAULT_PASS = ""
-DEFAULT_CONTROL_NAME = "Tesira Volume"
-DEFAULT_CHANNEL = 1
-DEFAULT_MIN_DB = -100.0
-DEFAULT_MAX_DB = 12.0
-DEFAULT_STEP_DB = 0.5
+def _device_schema(defaults: dict[str, Any] | None = None) -> vol.Schema:
+    d = defaults or {}
+    return vol.Schema(
+        {
+            vol.Required(CONF_IP, default=d.get(CONF_IP, DEFAULT_IP)): cv.string,
+            vol.Optional(CONF_PORT, default=d.get(CONF_PORT, DEFAULT_PORT)): cv.port,
+            vol.Required(CONF_PROTO, default=d.get(CONF_PROTO, DEFAULT_PROTO)): selector({
+                "select": {
+                    "options": [
+                        {"value": "ssh", "label": "SSH"},
+                        {"value": "telnet", "label": "Telnet"}
+                    ]
+                }
+            }),
+            vol.Optional(CONF_USER, default=d.get(CONF_USER, DEFAULT_USER)): cv.string,
+            vol.Optional(CONF_PASS, default=d.get(CONF_PASS, DEFAULT_PASS)): cv.string
+        }
+    )

--- a/custom_components/tesira_ttp/schemas.py
+++ b/custom_components/tesira_ttp/schemas.py
@@ -2,7 +2,7 @@
 # Filename: \custom_components\tesira_ttp\schemas.py                                                                   #
 # Repository: tesira_ttp                                                                                               #
 # Created Date: Thursday, March 19th 2026, 12:56:52 AM                                                                 #
-# Last Modified: Sunday, April 5th 2026, 9:10:10 PM                                                                    #
+# Last Modified: Monday, April 6th 2026, 10:10:59 PM                                                                   #
 # Original Author: Darnel Kumar                                                                                        #
 # Author Github: https://github.com/Darnel-K                                                                           #
 #                                                                                                                      #
@@ -33,7 +33,8 @@ from typing import Any
 from homeassistant.helpers.selector import selector
 from .const import (
     DOMAIN,
-    CONF_IP,
+    CONF_HUB_TITLE,
+    CONF_HOST,
     CONF_PORT,
     CONF_PROTO,
     CONF_USER,
@@ -58,11 +59,19 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
+def _hub(defaults: dict[str, Any] | None = None) -> vol.Schema:
+    d = defaults or {}
+    return vol.Schema(
+        {
+            vol.Required(CONF_HUB_TITLE, default=d.get(CONF_HUB_TITLE, "")): cv.string
+        }
+    )
+
 def _device_schema(defaults: dict[str, Any] | None = None) -> vol.Schema:
     d = defaults or {}
     return vol.Schema(
         {
-            vol.Required(CONF_IP, default=d.get(CONF_IP, DEFAULT_IP)): cv.string,
+            vol.Required(CONF_HOST, default=d.get(CONF_HOST, DEFAULT_IP)): cv.string,
             vol.Optional(CONF_PORT, default=d.get(CONF_PORT, DEFAULT_PORT)): cv.port,
             vol.Required(CONF_PROTO, default=d.get(CONF_PROTO, DEFAULT_PROTO)): selector({
                 "select": {

--- a/custom_components/tesira_ttp/schemas.py
+++ b/custom_components/tesira_ttp/schemas.py
@@ -2,7 +2,7 @@
 # Filename: \custom_components\tesira_ttp\schemas.py                                                                   #
 # Repository: tesira_ttp                                                                                               #
 # Created Date: Thursday, March 19th 2026, 12:56:52 AM                                                                 #
-# Last Modified: Monday, April 6th 2026, 10:10:59 PM                                                                   #
+# Last Modified: Sunday, April 12th 2026, 10:09:23 PM                                                                  #
 # Original Author: Darnel Kumar                                                                                        #
 # Author Github: https://github.com/Darnel-K                                                                           #
 #                                                                                                                      #
@@ -31,31 +31,7 @@ import homeassistant.helpers.config_validation as cv
 
 from typing import Any
 from homeassistant.helpers.selector import selector
-from .const import (
-    DOMAIN,
-    CONF_HUB_TITLE,
-    CONF_HOST,
-    CONF_PORT,
-    CONF_PROTO,
-    CONF_USER,
-    CONF_PASS,
-    DEFAULT_IP,
-    DEFAULT_PORT,
-    DEFAULT_PROTO,
-    DEFAULT_USER,
-    DEFAULT_PASS,
-    CONF_CONTROL_NAME,
-    CONF_INSTANCE_TAG,
-    CONF_CHANNEL,
-    CONF_MIN_DB,
-    CONF_MAX_DB,
-    CONF_STEP_DB,
-    DEFAULT_CONTROL_NAME,
-    DEFAULT_CHANNEL,
-    DEFAULT_MIN_DB,
-    DEFAULT_MAX_DB,
-    DEFAULT_STEP_DB
-)
+from .const import DOMAIN, DICT_KEYS, DEFAULTS
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -63,7 +39,7 @@ def _hub(defaults: dict[str, Any] | None = None) -> vol.Schema:
     d = defaults or {}
     return vol.Schema(
         {
-            vol.Required(CONF_HUB_TITLE, default=d.get(CONF_HUB_TITLE, "")): cv.string
+            vol.Required(DICT_KEYS["HUB_TITLE"], default=d.get(DICT_KEYS["HUB_TITLE"], "")): cv.string
         }
     )
 
@@ -71,9 +47,9 @@ def _device_schema(defaults: dict[str, Any] | None = None) -> vol.Schema:
     d = defaults or {}
     return vol.Schema(
         {
-            vol.Required(CONF_HOST, default=d.get(CONF_HOST, DEFAULT_IP)): cv.string,
-            vol.Optional(CONF_PORT, default=d.get(CONF_PORT, DEFAULT_PORT)): cv.port,
-            vol.Required(CONF_PROTO, default=d.get(CONF_PROTO, DEFAULT_PROTO)): selector({
+            vol.Required(DICT_KEYS["HOST"], default=d.get(DICT_KEYS["HOST"], DEFAULTS["HOST"])): cv.string,
+            vol.Optional(DICT_KEYS["PORT"], default=d.get(DICT_KEYS["PORT"], DEFAULTS["PORT"])): cv.port,
+            vol.Required(DICT_KEYS["PROTO"], default=d.get(DICT_KEYS["PROTO"], DEFAULTS["PROTO"])): selector({
                 "select": {
                     "options": [
                         {"value": "ssh", "label": "SSH"},
@@ -81,8 +57,8 @@ def _device_schema(defaults: dict[str, Any] | None = None) -> vol.Schema:
                     ]
                 }
             }),
-            vol.Optional(CONF_USER, default=d.get(CONF_USER, DEFAULT_USER)): cv.string,
-            vol.Optional(CONF_PASS, default=d.get(CONF_PASS, DEFAULT_PASS)): cv.string
+            vol.Optional(DICT_KEYS["USER"], default=d.get(DICT_KEYS["USER"], DEFAULTS["USER"])): cv.string,
+            vol.Optional(DICT_KEYS["PASS"], default=d.get(DICT_KEYS["PASS"], DEFAULTS["PASS"])): cv.string
         }
     )
 
@@ -90,11 +66,11 @@ def _control_schema(defaults: dict[str, Any] | None = None) -> vol.Schema:
     d = defaults or {}
     return vol.Schema(
         {
-            vol.Optional(CONF_CONTROL_NAME, default=d.get(CONF_CONTROL_NAME, DEFAULT_CONTROL_NAME)): cv.string,
-            vol.Required(CONF_INSTANCE_TAG, default=d.get(CONF_INSTANCE_TAG, "volume")): cv.string,
-            vol.Optional(CONF_CHANNEL, default=int(d.get(CONF_CHANNEL, DEFAULT_CHANNEL))): vol.Coerce(int),
-            vol.Optional(CONF_MIN_DB, default=float(d.get(CONF_MIN_DB, DEFAULT_MIN_DB))): vol.Coerce(float),
-            vol.Optional(CONF_MAX_DB, default=float(d.get(CONF_MAX_DB, DEFAULT_MAX_DB))): vol.Coerce(float),
-            vol.Optional(CONF_STEP_DB, default=float(d.get(CONF_STEP_DB, DEFAULT_STEP_DB))): vol.Coerce(float),
+            vol.Optional(DICT_KEYS["CONTROL_NAME"], default=d.get(DICT_KEYS["CONTROL_NAME"], DEFAULTS["CONTROL_NAME"])): cv.string,
+            vol.Required(DICT_KEYS["INSTANCE_TAG"], default=d.get(DICT_KEYS["INSTANCE_TAG"], "volume")): cv.string,
+            vol.Optional(DICT_KEYS["CHANNEL"], default=int(d.get(DICT_KEYS["CHANNEL"], DEFAULTS["CHANNEL"]))): vol.Coerce(int),
+            vol.Optional(DICT_KEYS["MIN_DB"], default=float(d.get(DICT_KEYS["MIN_DB"], DEFAULTS["MIN_DB"]))): vol.Coerce(float),
+            vol.Optional(DICT_KEYS["MAX_DB"], default=float(d.get(DICT_KEYS["MAX_DB"], DEFAULTS["MAX_DB"]))): vol.Coerce(float),
+            vol.Optional(DICT_KEYS["STEP_DB"], default=float(d.get(DICT_KEYS["STEP_DB"], DEFAULTS["STEP_DB"]))): vol.Coerce(float),
         }
     )

--- a/custom_components/tesira_ttp/strings.json
+++ b/custom_components/tesira_ttp/strings.json
@@ -4,6 +4,13 @@
     "config": {
         "step": {
             "user": {
+                "title": "Set hub title",
+                "description": "Enter a title for this hub. This is used to differentiate between multiple Tesira systems if you have more than one and will be displayed in the Home Assistant UI.",
+                "data": {
+                    "hub_title": "Hub title"
+                }
+            },
+            "add_first_device": {
                 "title": "Connect your Tesira DSP",
                 "description": "Enter the Tesira DSP host, port, protocol & credentials for the Tesira Text Protocol server.",
                 "data": {
@@ -15,14 +22,64 @@
                 }
             },
             "reconfigure": {
-                "title": "Reconfigure Tesira DSP connection",
-                "description": "Enter the Tesira DSP host, port, protocol & credentials for the Tesira Text Protocol server.",
+                "title": "Configure Tesira Text Protocol settings",
+                "menu_options": {
+                    "edit_hub_title": "Change hub title",
+                    "devices": "Configure Devices"
+                }
+            },
+            "edit_hub_title": {
+                "title": "Change hub title",
+                "description": "You can change the hub title here. This is used to differentiate between multiple Tesira systems if you have more than one and will be displayed in the Home Assistant UI.",
+                "data": {
+                    "hub_title": "Hub title"
+                }
+            },
+            "devices": {
+                "title": "Configure Devices",
+                "menu_options": {
+                    "add_device": "Add Device",
+                    "select_device": "Edit Device",
+                    "remove_device": "Remove Device",
+                    "change_primary": "Change Primary Device"
+                }
+            },
+            "add_device": {
+                "title": "Add Device",
                 "data": {
                     "host": "Host",
                     "port": "Port",
                     "protocol": "Protocol",
                     "username": "Username (SSH only)",
                     "password": "Password (SSH only)"
+                }
+            },
+            "select_device": {
+                "title": "Select Device",
+                "data": {
+                    "select": "Select a device to edit"
+                }
+            },
+            "edit_device": {
+                "title": "Edit Device",
+                "data": {
+                    "host": "Host",
+                    "port": "Port",
+                    "protocol": "Protocol",
+                    "username": "Username (SSH only)",
+                    "password": "Password (SSH only)"
+                }
+            },
+            "remove_device": {
+                "title": "Remove Devices",
+                "data": {
+                    "select": "Select a device to remove"
+                }
+            },
+            "change_primary": {
+                "title": "Change Primary Device",
+                "data": {
+                    "select": "Select a device to change to primary"
                 }
             },
             "control": {
@@ -44,57 +101,25 @@
             "unsupported_authentication": "Authentication is not supported when using Telnet. Please switch to SSH or leave username as default and password blank.",
             "unknown": "An unknown error occurred.",
             "device_info_failed": "Connected to the Tesira device but failed to retrieve device information. Please check the connection and try again.",
-            "different_device": "The provided connection details correspond to a different Tesira device than the one currently configured. Please check your input and try again."
+            "different_device": "The provided connection details correspond to a different Tesira device than the one currently configured. Please check your input and try again.",
+            "device_not_found": "The device was not found in the existing configuration. This should never happen. Please check your input and try again.",
+            "device_exists": "A device with the same ID already exists in the configuration. Please check your input and try again.",
+            "cannot_remove_primary": "Cannot remove the primary device. Please change the primary device before removing this one.",
+            "already_primary": "Selected device is already the primary device."
         },
         "abort": {
             "already_configured": "This Tesira device is already configured.",
-            "reconfigure_successful": "Tesira DSP connection reconfigured successfully."
+            "reconfigure_successful": "Tesira DSP connection reconfigured successfully.",
+            "no_devices": "No devices are configured. Please add a device first.",
+            "device_removed": "Device(s) removed successfully.",
+            "device_updated": "Device updated successfully.",
+            "primary_changed": "Primary device changed successfully.",
+            "device_added": "Device added successfully."
         }
     },
     "options": {
         "step": {
             "init": {
-                "title": "Configure Tesira Text Protocol options",
-                "menu_options": {
-                    "devices": "Configure Devices",
-                    "entities": "Configure Entities"
-                }
-            },
-            "devices": {
-                "title": "Configure Devices",
-                "menu_options": {
-                    "add_device": "Add Device",
-                    "edit_device": "Edit Device",
-                    "remove_device": "Remove Device"
-                }
-            },
-            "add_device": {
-                "title": "Add Device",
-                "data": {
-                    "host": "Host",
-                    "port": "Port",
-                    "protocol": "Protocol",
-                    "username": "Username (SSH only)",
-                    "password": "Password (SSH only)"
-                }
-            },
-            "select_device": {
-                "title": "Select Device"
-            },
-            "edit_device": {
-                "title": "Edit Device",
-                "data": {
-                    "host": "Host",
-                    "port": "Port",
-                    "protocol": "Protocol",
-                    "username": "Username (SSH only)",
-                    "password": "Password (SSH only)"
-                }
-            },
-            "remove_device": {
-                "title": "Remove Devices"
-            },
-            "entities": {
                 "title": "Configure Entities",
                 "menu_options": {
                     "add_entity": "Add Entity",

--- a/custom_components/tesira_ttp/strings.json
+++ b/custom_components/tesira_ttp/strings.json
@@ -54,15 +54,56 @@
     "options": {
         "step": {
             "init": {
-                "title": "Configure controls",
+                "title": "Configure Tesira Text Protocol options",
                 "menu_options": {
-                    "add": "Add control",
-                    "edit": "Edit control",
-                    "remove": "Remove control"
+                    "devices": "Configure Devices",
+                    "entities": "Configure Entities"
                 }
             },
-            "add": {
-                "title": "Add control",
+            "devices": {
+                "title": "Configure Devices",
+                "menu_options": {
+                    "add_device": "Add Device",
+                    "edit_device": "Edit Device",
+                    "remove_device": "Remove Device"
+                }
+            },
+            "add_device": {
+                "title": "Add Device",
+                "data": {
+                    "host": "Host",
+                    "port": "Port",
+                    "protocol": "Protocol",
+                    "username": "Username (SSH only)",
+                    "password": "Password (SSH only)"
+                }
+            },
+            "select_device": {
+                "title": "Select Device"
+            },
+            "edit_device": {
+                "title": "Edit Device",
+                "data": {
+                    "host": "Host",
+                    "port": "Port",
+                    "protocol": "Protocol",
+                    "username": "Username (SSH only)",
+                    "password": "Password (SSH only)"
+                }
+            },
+            "remove_device": {
+                "title": "Remove Devices"
+            },
+            "entities": {
+                "title": "Configure Entities",
+                "menu_options": {
+                    "add_entity": "Add Entity",
+                    "select_entity": "Edit Entity",
+                    "remove_entity": "Remove Entity"
+                }
+            },
+            "add_entity": {
+                "title": "Add Entity",
                 "data": {
                     "name": "Name",
                     "instance_tag": "Instance tag",
@@ -72,11 +113,11 @@
                     "step_db": "Step dB"
                 }
             },
-            "edit": {
-                "title": "Select control"
+            "select_entity": {
+                "title": "Select Entity"
             },
-            "edit_control": {
-                "title": "Edit control",
+            "edit_entity": {
+                "title": "Edit Entity",
                 "data": {
                     "name": "Name",
                     "instance_tag": "Instance tag",
@@ -86,12 +127,12 @@
                     "step_db": "Step dB"
                 }
             },
-            "remove": {
-                "title": "Remove controls"
+            "remove_entity": {
+                "title": "Remove Entities"
             }
         },
         "abort": {
-            "no_controls": "No controls are configured."
+            "no_controls": "No entities are configured."
         }
     }
 }

--- a/custom_components/tesira_ttp/tesira_client.py
+++ b/custom_components/tesira_ttp/tesira_client.py
@@ -2,7 +2,7 @@
 # Filename: \custom_components\tesira_ttp\tesira_client.py                                                             #
 # Repository: tesira_ttp                                                                                               #
 # Created Date: Thursday, March 19th 2026, 12:56:52 AM                                                                 #
-# Last Modified: Monday, March 30th 2026, 3:26:17 PM                                                                   #
+# Last Modified: Monday, April 13th 2026, 12:11:16 AM                                                                  #
 # Original Author: Darnel Kumar                                                                                        #
 # Author Github: https://github.com/Darnel-K                                                                           #
 #                                                                                                                      #
@@ -121,26 +121,30 @@ class TesiraClient:
             self.buffer = ""
             self.complete = asyncio.Event()
 
+            # NEW: framing state
+            self.ok_seen = False
+            self._last_rx = asyncio.get_event_loop().time()
+
         def data_received(self, data, datatype=None):
             if not data:
                 return
 
             self.buffer += data
+            self._last_rx = asyncio.get_event_loop().time()
+
             _LOGGER.debug("[RX/TELNET] %s", repr(data))
 
-            # Detect +OK or -ERR
-            if "+OK" in self.buffer or "-ERR" in self.buffer:
+            if "+OK" in data or "-ERR" in data:
+                self.ok_seen = True
                 self.complete.set()
 
-            # Publish-token events
-            for line in self.buffer.splitlines():
+            for line in data.splitlines():
                 if line.strip().startswith("! "):
                     self.parent._handle_publish_event(line.strip())
 
         def connection_lost(self, exc):
             _LOGGER.warning("[TELNET] Connection lost.")
             self.complete.set()
-
 
     # =====================================================================
     # INTERNAL SSH SESSION
@@ -152,14 +156,25 @@ class TesiraClient:
             self.buffer = ""
             self.complete = asyncio.Event()
 
+            # NEW: framing state
+            self.ok_seen = False
+            self._last_rx = asyncio.get_event_loop().time()
+
         def data_received(self, data, datatype):
+            if not data:
+                return
+
             self.buffer += data
+            self._last_rx = asyncio.get_event_loop().time()
 
             _LOGGER.debug("[RX/SSH] %s", repr(data))
 
-            if "+OK" in self.buffer or "-ERR" in self.buffer:
+            # Detect status prefix, but DO NOT signal completion yet
+            if "+OK" in data or "-ERR" in data:
+                self.ok_seen = True
                 self.complete.set()
 
+            # Publish-token events
             for line in data.splitlines():
                 if line.strip().startswith("! "):
                     self.parent._handle_publish_event(line.strip())
@@ -167,7 +182,6 @@ class TesiraClient:
         def connection_lost(self, exc):
             _LOGGER.warning("[SSH] Connection lost")
             self.complete.set()
-
 
     # =====================================================================
     # TELNET READER TASK
@@ -303,30 +317,54 @@ class TesiraClient:
     # =====================================================================
     # COMMAND ENGINE (SSH + TELNET, fragmentation safe)
     # =====================================================================
-    async def command(self, cmd: str, timeout=5.0):
+    async def command(self, cmd: str, timeout: float = 5.0):
         async with self._lock:
             await self.connect()
 
-            # reset
+            # Reset session state
             self._session.buffer = ""
             self._session.complete.clear()
+            self._session.ok_seen = False
+            self._session._last_rx = asyncio.get_event_loop().time()
 
             _LOGGER.debug("[TX] %s", cmd)
 
             await self._send(cmd + "\r\n")
 
+            # Wait until we see the response start (+OK or -ERR)
             try:
                 await asyncio.wait_for(self._session.complete.wait(), timeout)
             except asyncio.TimeoutError:
-                raise self.TimeoutError("Timeout waiting for +OK or -ERR", raw=self._session.buffer, cmd=cmd)
+                raise self.TimeoutError(
+                    "Timeout waiting for +OK or -ERR",
+                    raw=self._session.buffer,
+                    cmd=cmd,
+                )
+
+            # --- NEW: idle-grace tail wait for large payloads ---
+            IDLE_GRACE = 0.15  # seconds; safe for multi‑kb responses
+
+            while True:
+                await asyncio.sleep(IDLE_GRACE)
+                now = asyncio.get_event_loop().time()
+                if now - self._session._last_rx >= IDLE_GRACE:
+                    break
+            # ---------------------------------------------------
 
             raw = self._session.buffer.strip()
             lines = [l.strip() for l in raw.splitlines()]
 
-            final = next((l for l in lines if l.startswith("+OK") or l.startswith("-ERR")), None)
+            final = next(
+                (l for l in lines if l.startswith("+OK") or l.startswith("-ERR")),
+                None,
+            )
 
             if not final:
-                raise self.CommandError("No +OK/-ERR returned", raw=raw, cmd=cmd)
+                raise self.CommandError(
+                    "No +OK/-ERR returned",
+                    raw=raw,
+                    cmd=cmd,
+                )
 
             if final.startswith("-ERR"):
                 if self.safe_mode:
@@ -334,7 +372,6 @@ class TesiraClient:
                 raise self.CommandError(final, raw=raw, cmd=cmd)
 
             return final
-
 
     # =====================================================================
     # JSON PARSER
@@ -354,11 +391,22 @@ class TesiraClient:
 
         payload = re.sub(r"\[([^\[\]]+)\]", fix_array, payload)
 
-        # Insert commas
+        # Insert commas between values and the next quoted key
+        payload = re.sub(r'([A-Za-z0-9_"\}\]])\s+"', r'\1, "', payload)
+
+        # Insert commas between quoted fields
         payload = re.sub(r'"\s+"', '", "', payload)
 
+        # Wrap in object if required
         if not payload.startswith("{"):
             payload = "{" + payload + "}"
+
+        # Quote unquoted enum literals
+        payload = re.sub(
+            r':([A-Z_][A-Z0-9_]*)\b(?!")',
+            r':"\1"',
+            payload
+        )
 
         try:
             return json.loads(payload)

--- a/custom_components/tesira_ttp/translations/en.json
+++ b/custom_components/tesira_ttp/translations/en.json
@@ -4,6 +4,13 @@
     "config": {
         "step": {
             "user": {
+                "title": "Set hub title",
+                "description": "Enter a title for this hub. This is used to differentiate between multiple Tesira systems if you have more than one and will be displayed in the Home Assistant UI.",
+                "data": {
+                    "hub_title": "Hub title"
+                }
+            },
+            "add_first_device": {
                 "title": "Connect your Tesira DSP",
                 "description": "Enter the Tesira DSP host, port, protocol & credentials for the Tesira Text Protocol server.",
                 "data": {
@@ -15,8 +22,30 @@
                 }
             },
             "reconfigure": {
-                "title": "Reconfigure Tesira DSP connection",
-                "description": "Enter the Tesira DSP host, port, protocol & credentials for the Tesira Text Protocol server.",
+                "title": "Configure Tesira Text Protocol settings",
+                "menu_options": {
+                    "edit_hub_title": "Change hub title",
+                    "devices": "Configure Devices"
+                }
+            },
+            "edit_hub_title": {
+                "title": "Change hub title",
+                "description": "You can change the hub title here. This is used to differentiate between multiple Tesira systems if you have more than one and will be displayed in the Home Assistant UI.",
+                "data": {
+                    "hub_title": "Hub title"
+                }
+            },
+            "devices": {
+                "title": "Configure Devices",
+                "menu_options": {
+                    "add_device": "Add Device",
+                    "select_device": "Edit Device",
+                    "remove_device": "Remove Device",
+                    "change_primary": "Change Primary Device"
+                }
+            },
+            "add_device": {
+                "title": "Add Device",
                 "data": {
                     "host": "Host",
                     "port": "Port",
@@ -24,6 +53,28 @@
                     "username": "Username (SSH only)",
                     "password": "Password (SSH only)"
                 }
+            },
+            "select_device": {
+                "title": "Select Device",
+                "data": {
+                    "select": "Select a device to edit"
+                }
+            },
+            "edit_device": {
+                "title": "Edit Device",
+                "data": {
+                    "host": "Host",
+                    "port": "Port",
+                    "protocol": "Protocol",
+                    "username": "Username (SSH only)",
+                    "password": "Password (SSH only)"
+                }
+            },
+            "remove_device": {
+                "title": "Remove Devices"
+            },
+            "change_primary": {
+                "title": "Change Primary Device"
             },
             "control": {
                 "title": "Add first control",
@@ -44,57 +95,23 @@
             "unsupported_authentication": "Authentication is not supported when using Telnet. Please switch to SSH or leave username as default and password blank.",
             "unknown": "An unknown error occurred.",
             "device_info_failed": "Connected to the Tesira device but failed to retrieve device information. Please check the connection and try again.",
-            "different_device": "The provided connection details correspond to a different Tesira device than the one currently configured. Please check your input and try again."
+            "different_device": "The provided connection details correspond to a different Tesira device than the one currently configured. Please check your input and try again.",
+            "device_not_found": "The device ID generated from the provided connection details was not found in the existing configuration. This should never happen. Please check your input and try again.",
+            "device_exists": "A device with the same ID already exists in the configuration. Please check your input and try again."
         },
         "abort": {
             "already_configured": "This Tesira device is already configured.",
-            "reconfigure_successful": "Tesira DSP connection reconfigured successfully."
+            "reconfigure_successful": "Tesira DSP connection reconfigured successfully.",
+            "no_devices": "No devices are configured. Please add a device first.",
+            "device_removed": "Device(s) removed successfully.",
+            "device_updated": "Device updated successfully.",
+            "primary_changed": "Primary device changed successfully.",
+            "device_added": "Device added successfully."
         }
     },
     "options": {
         "step": {
             "init": {
-                "title": "Configure Tesira Text Protocol options",
-                "menu_options": {
-                    "devices": "Configure Devices",
-                    "entities": "Configure Entities"
-                }
-            },
-            "devices": {
-                "title": "Configure Devices",
-                "menu_options": {
-                    "add_device": "Add Device",
-                    "edit_device": "Edit Device",
-                    "remove_device": "Remove Device"
-                }
-            },
-            "add_device": {
-                "title": "Add Device",
-                "data": {
-                    "host": "Host",
-                    "port": "Port",
-                    "protocol": "Protocol",
-                    "username": "Username (SSH only)",
-                    "password": "Password (SSH only)"
-                }
-            },
-            "select_device": {
-                "title": "Select Device"
-            },
-            "edit_device": {
-                "title": "Edit Device",
-                "data": {
-                    "host": "Host",
-                    "port": "Port",
-                    "protocol": "Protocol",
-                    "username": "Username (SSH only)",
-                    "password": "Password (SSH only)"
-                }
-            },
-            "remove_device": {
-                "title": "Remove Devices"
-            },
-            "entities": {
                 "title": "Configure Entities",
                 "menu_options": {
                     "add_entity": "Add Entity",

--- a/custom_components/tesira_ttp/translations/en.json
+++ b/custom_components/tesira_ttp/translations/en.json
@@ -54,15 +54,56 @@
     "options": {
         "step": {
             "init": {
-                "title": "Configure controls",
+                "title": "Configure Tesira Text Protocol options",
                 "menu_options": {
-                    "add": "Add control",
-                    "edit": "Edit control",
-                    "remove": "Remove control"
+                    "devices": "Configure Devices",
+                    "entities": "Configure Entities"
                 }
             },
-            "add": {
-                "title": "Add control",
+            "devices": {
+                "title": "Configure Devices",
+                "menu_options": {
+                    "add_device": "Add Device",
+                    "edit_device": "Edit Device",
+                    "remove_device": "Remove Device"
+                }
+            },
+            "add_device": {
+                "title": "Add Device",
+                "data": {
+                    "host": "Host",
+                    "port": "Port",
+                    "protocol": "Protocol",
+                    "username": "Username (SSH only)",
+                    "password": "Password (SSH only)"
+                }
+            },
+            "select_device": {
+                "title": "Select Device"
+            },
+            "edit_device": {
+                "title": "Edit Device",
+                "data": {
+                    "host": "Host",
+                    "port": "Port",
+                    "protocol": "Protocol",
+                    "username": "Username (SSH only)",
+                    "password": "Password (SSH only)"
+                }
+            },
+            "remove_device": {
+                "title": "Remove Devices"
+            },
+            "entities": {
+                "title": "Configure Entities",
+                "menu_options": {
+                    "add_entity": "Add Entity",
+                    "select_entity": "Edit Entity",
+                    "remove_entity": "Remove Entity"
+                }
+            },
+            "add_entity": {
+                "title": "Add Entity",
                 "data": {
                     "name": "Name",
                     "instance_tag": "Instance tag",
@@ -72,11 +113,11 @@
                     "step_db": "Step dB"
                 }
             },
-            "edit": {
-                "title": "Select control"
+            "select_entity": {
+                "title": "Select Entity"
             },
-            "edit_control": {
-                "title": "Edit control",
+            "edit_entity": {
+                "title": "Edit Entity",
                 "data": {
                     "name": "Name",
                     "instance_tag": "Instance tag",
@@ -86,12 +127,12 @@
                     "step_db": "Step dB"
                 }
             },
-            "remove": {
-                "title": "Remove controls"
+            "remove_entity": {
+                "title": "Remove Entities"
             }
         },
         "abort": {
-            "no_controls": "No controls are configured."
+            "no_controls": "No entities are configured."
         }
     }
 }

--- a/custom_components/tesira_ttp/util.py
+++ b/custom_components/tesira_ttp/util.py
@@ -2,7 +2,7 @@
 # Filename: \custom_components\tesira_ttp\util.py                                                                      #
 # Repository: tesira_ttp                                                                                               #
 # Created Date: Thursday, March 19th 2026, 12:56:52 AM                                                                 #
-# Last Modified: Sunday, April 5th 2026, 9:19:42 PM                                                                    #
+# Last Modified: Tuesday, April 7th 2026, 11:21:40 PM                                                                  #
 # Original Author: Darnel Kumar                                                                                        #
 # Author Github: https://github.com/Darnel-K                                                                           #
 #                                                                                                                      #
@@ -26,14 +26,55 @@
 
 from __future__ import annotations
 
-from typing import Dict
+from typing import Dict, Any
+from .const import DOMAIN, CONF_HOST, CONF_PORT, CONF_PROTO, CONF_USER, CONF_PASS
 
 import base64
 import json
+import copy
 
-def gen_hub_key(deviceModel: str, deviceRevision: int, serialNumber: str, format: str = "b64") -> str:
+def gen_device_dict(host: str, port: int, proto: str, user: str, pwrd: str, device_info: dict, device_id: str = None) -> Dict[str, Any]:
     """
-    Generate a unique key for a Tesira hub based on connection parameters.
+    Generate a dictionary template for a Tesira device.
+
+    Returns:
+        A dictionary with the structure for storing device information and connection details.
+    """
+    if device_id is None:
+        device_id = gen_device_id(device_info["deviceModel"], device_info["deviceRevision"], device_info["serialNumber"])
+    return {
+        "connection_info": {
+            CONF_HOST: host,
+            CONF_PORT: port,
+            CONF_PROTO: proto,
+            "auth": {
+                CONF_USER: user,
+                CONF_PASS: pwrd
+            }
+        },
+        "device_info": {
+            "name": f"Biamp - {device_info['deviceModel']} - {device_info['serialNumber']} - {host}:{port}",
+            "manufacturer": "Biamp",
+            "model": device_info["deviceModel"],
+            "model_id": device_info["deviceModel"],
+            "sw_version": device_info["firmwareVersion"],
+            "hw_version": device_info["deviceRevision"],
+            "serial_number": device_info["serialNumber"]
+        }
+    }
+
+def _redact_device(device: dict[str, Any]) -> dict[str, Any]:
+    redacted = copy.deepcopy(device)
+    auth = redacted.get("connection_info", {}).get("auth")
+    if auth:
+        auth[CONF_USER] = "***"
+        auth[CONF_PASS] = "***"
+    return redacted
+
+
+def gen_device_id(deviceModel: str, deviceRevision: int, serialNumber: str, format: str = "b64") -> str:
+    """
+    Generate a unique key for a Tesira device based on its properties.
 
     Args:
 
@@ -43,29 +84,29 @@ def gen_hub_key(deviceModel: str, deviceRevision: int, serialNumber: str, format
         format: The output format of the key ("b64" for base64, "plain" for raw string, "json" for JSON).
 
     Returns:
-        A unique string key representing the hub configuration.
+        A unique string key representing the device configuration.
     """
     ALLOWED_FORMATS = {"b64", "plain", "json"}
-    hub_key = {"deviceModel": deviceModel.lower(), "deviceRevision": deviceRevision.lower(), "serialNumber": serialNumber.lower()}
+    device_id = {"deviceModel": deviceModel.lower(), "deviceRevision": deviceRevision.lower(), "serialNumber": serialNumber.lower()}
     format = format.lower().strip()
     if format not in ALLOWED_FORMATS:
             raise ValueError(f"Unsupported format '{format}'. Allowed: {ALLOWED_FORMATS}")
 
     match format:
         case "json":
-             return json.dumps(hub_key, sort_keys=True)
+             return json.dumps(device_id, sort_keys=True)
         case "plain":
-             return f"{hub_key['deviceModel']}:{hub_key['deviceRevision']}:{hub_key['serialNumber']}"
+             return f"{device_id['deviceModel']}:{device_id['deviceRevision']}:{device_id['serialNumber']}"
         case "b64":
-             return base64.urlsafe_b64encode(json.dumps(hub_key, sort_keys=True).encode()).decode()
+             return base64.urlsafe_b64encode(json.dumps(device_id, sort_keys=True).encode()).decode()
 
-def parse_hub_key(hub_key: str, format: str = "b64") -> Dict[str, str]:
+def parse_device_id(device_id: str, format: str = "b64") -> Dict[str, str]:
     """
-    Parse a hub key back into its components.
+    Parse a device ID back into its components.
 
     Args:
-        hub_key: The unique key representing the hub configuration.
-        format: The format of the input key ("b64" for base64, "plain" for raw string, "json" for JSON).
+        device_id: The unique ID representing the device configuration.
+        format: The format of the input ID ("b64" for base64, "plain" for raw string, "json" for JSON).
 
     Returns:
         A dictionary containing the original parameters (deviceModel, deviceRevision, serialNumber).
@@ -77,14 +118,14 @@ def parse_hub_key(hub_key: str, format: str = "b64") -> Dict[str, str]:
 
     match format:
         case "json":
-             return json.loads(hub_key)
+             return json.loads(device_id)
         case "plain":
-             parts = hub_key.split(":")
+             parts = device_id.split(":")
              if len(parts) != 3:
                  raise ValueError("Invalid plain format. Expected 'deviceModel:deviceRevision:serialNumber'")
              return {"deviceModel": parts[0], "deviceRevision": parts[1], "serialNumber": parts[2]}
         case "b64":
-             decoded = base64.urlsafe_b64decode(hub_key.encode()).decode()
+             decoded = base64.urlsafe_b64decode(device_id.encode()).decode()
              return json.loads(decoded)
 
 class TesiraTTPException(Exception):

--- a/custom_components/tesira_ttp/util.py
+++ b/custom_components/tesira_ttp/util.py
@@ -2,7 +2,7 @@
 # Filename: \custom_components\tesira_ttp\util.py                                                                      #
 # Repository: tesira_ttp                                                                                               #
 # Created Date: Thursday, March 19th 2026, 12:56:52 AM                                                                 #
-# Last Modified: Tuesday, April 7th 2026, 11:21:40 PM                                                                  #
+# Last Modified: Sunday, April 12th 2026, 10:05:27 PM                                                                  #
 # Original Author: Darnel Kumar                                                                                        #
 # Author Github: https://github.com/Darnel-K                                                                           #
 #                                                                                                                      #
@@ -27,7 +27,7 @@
 from __future__ import annotations
 
 from typing import Dict, Any
-from .const import DOMAIN, CONF_HOST, CONF_PORT, CONF_PROTO, CONF_USER, CONF_PASS
+from .const import DOMAIN, DICT_KEYS
 
 import base64
 import json
@@ -44,12 +44,12 @@ def gen_device_dict(host: str, port: int, proto: str, user: str, pwrd: str, devi
         device_id = gen_device_id(device_info["deviceModel"], device_info["deviceRevision"], device_info["serialNumber"])
     return {
         "connection_info": {
-            CONF_HOST: host,
-            CONF_PORT: port,
-            CONF_PROTO: proto,
+            DICT_KEYS["HOST"]: host,
+            DICT_KEYS["PORT"]: port,
+            DICT_KEYS["PROTO"]: proto,
             "auth": {
-                CONF_USER: user,
-                CONF_PASS: pwrd
+                DICT_KEYS["USER"]: user,
+                DICT_KEYS["PASS"]: pwrd
             }
         },
         "device_info": {
@@ -67,8 +67,8 @@ def _redact_device(device: dict[str, Any]) -> dict[str, Any]:
     redacted = copy.deepcopy(device)
     auth = redacted.get("connection_info", {}).get("auth")
     if auth:
-        auth[CONF_USER] = "***"
-        auth[CONF_PASS] = "***"
+        auth[DICT_KEYS["USER"]] = "***"
+        auth[DICT_KEYS["PASS"]] = "***"
     return redacted
 
 

--- a/custom_components/tesira_ttp/util.py
+++ b/custom_components/tesira_ttp/util.py
@@ -1,8 +1,8 @@
 # #################################################################################################################### #
 # Filename: \custom_components\tesira_ttp\util.py                                                                      #
 # Repository: tesira_ttp                                                                                               #
-# Created Date: Saturday, March 28th 2026, 10:45:20 PM                                                                 #
-# Last Modified: Friday, April 3rd 2026, 9:21:44 PM                                                                    #
+# Created Date: Thursday, March 19th 2026, 12:56:52 AM                                                                 #
+# Last Modified: Sunday, April 5th 2026, 9:19:42 PM                                                                    #
 # Original Author: Darnel Kumar                                                                                        #
 # Author Github: https://github.com/Darnel-K                                                                           #
 #                                                                                                                      #
@@ -26,50 +26,10 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Dict
 
-import voluptuous as vol
 import base64
 import json
-
-# =====================================================================
-# Schema Helpers
-# =====================================================================
-def schema_with_defaults(
-    base_schema: vol.Schema, defaults: Dict[str, Any]
-) -> vol.Schema:
-    """
-    Create a new voluptuous Schema with runtime default values injected.
-
-    This **does not** modify the passed-in base schema.
-
-    Args:
-        base_schema: The original schema to copy fields from.
-        defaults: A dictionary mapping field names -> default values.
-
-    Returns:
-        A new vol.Schema instance where matching fields are replaced with
-        new Required/Optional fields containing default values.
-    """
-    new_fields: Dict[Any, Any] = {}
-
-    # base_schema.schema contains {vol.Required/vol.Optional: validator}
-    for key, validator in base_schema.schema.items():
-        field_name = key.schema  # the raw field name string
-
-        if field_name in defaults:
-            default_value = defaults[field_name]
-
-            # Replace field with one that has a default applied
-            if isinstance(key, vol.Required):
-                new_fields[vol.Required(field_name, default=default_value)] = validator
-            else:
-                new_fields[vol.Optional(field_name, default=default_value)] = validator
-        else:
-            # Leave untouched
-            new_fields[key] = validator
-
-    return vol.Schema(new_fields)
 
 def gen_hub_key(deviceModel: str, deviceRevision: int, serialNumber: str, format: str = "b64") -> str:
     """


### PR DESCRIPTION
 - Additional devices can now be added to a hub via the config/reconfiguration flows
   - Editing, removing & changing primary device now available from the reconfiguration flow
 - Each device automatically registers a binary sensor entity to monitor network connectivity state
 - Hub now pulls connection details from the primary device
 - Hub automatically registers a binary sensor entity to monitor SSH/Telnet connection state
 - Hub title/name is now changeable via the reconfiguration flow
 - JSON paring issues fixed