### PR TITLE
feat: add Tesira logic block entity support across switch, number, button, and binary sensor platforms

### DIFF
--- a/custom_components/tesira_ttp/binary_sensor.py
+++ b/custom_components/tesira_ttp/binary_sensor.py
@@ -1,8 +1,8 @@
 # #################################################################################################################### #
 # Filename: \custom_components\tesira_ttp\binary_sensor.py                                                             #
 # Repository: tesira_ttp                                                                                               #
-# Created Date: Thursday, April 16th 2026, 11:44:37 PM                                                                 #
-# Last Modified: Wednesday, July 8th 2026, 12:07:19 AM                                                                 #
+# Created Date: Tuesday, July 7th 2026, 11:50:58 PM                                                                    #
+# Last Modified: Wednesday, July 8th 2026, 12:36:42 AM                                                                 #
 # Original Author: Darnel Kumar                                                                                        #
 # Author Github: https://github.com/Darnel-K                                                                           #
 #                                                                                                                      #
@@ -43,6 +43,8 @@ from typing import Any
 _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities):
+    """Set up Tesira binary sensor entities for a config entry."""
+
     hubkey = entry.entry_id
     hub: TesiraHub = hass.data[DOMAIN][DICT_KEYS["DATA_HUBS"]][hubkey]
     devices = copy.deepcopy(entry.data.get(DICT_KEYS["DEVICES"], DEFAULTS["DEVICES"]))

--- a/custom_components/tesira_ttp/binary_sensor.py
+++ b/custom_components/tesira_ttp/binary_sensor.py
@@ -1,8 +1,8 @@
 # #################################################################################################################### #
 # Filename: \custom_components\tesira_ttp\binary_sensor.py                                                             #
 # Repository: tesira_ttp                                                                                               #
-# Created Date: Monday, April 13th 2026, 12:33:01 AM                                                                   #
-# Last Modified: Tuesday, July 7th 2026, 11:06:42 PM                                                                   #
+# Created Date: Thursday, April 16th 2026, 11:44:37 PM                                                                 #
+# Last Modified: Tuesday, July 7th 2026, 11:08:47 PM                                                                   #
 # Original Author: Darnel Kumar                                                                                        #
 # Author Github: https://github.com/Darnel-K                                                                           #
 #                                                                                                                      #
@@ -55,6 +55,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
             match entity[DICT_KEYS["ENTITY_BLOCK_TYPE"]]:
                 case "logic_meter":
                     entities_list.append(TesiraLogicMeterBlock(hub=hub, hubkey=hubkey, entity=entity))
+                case "logic_pulse":
+                    entities_list.append(TesiraLogicPulseBlock(hub=hub, hubkey=hubkey, entity=entity))
                 case _:
                     _LOGGER.debug(
                         "Unsupported binary sensor block type '%s' for entity: %s",

--- a/custom_components/tesira_ttp/binary_sensor.py
+++ b/custom_components/tesira_ttp/binary_sensor.py
@@ -1,8 +1,8 @@
 # #################################################################################################################### #
 # Filename: \custom_components\tesira_ttp\binary_sensor.py                                                             #
 # Repository: tesira_ttp                                                                                               #
-# Created Date: Friday, May 8th 2026, 10:59:43 PM                                                                      #
-# Last Modified: Tuesday, July 7th 2026, 11:26:25 PM                                                                   #
+# Created Date: Thursday, April 16th 2026, 11:44:37 PM                                                                 #
+# Last Modified: Wednesday, July 8th 2026, 12:07:19 AM                                                                 #
 # Original Author: Darnel Kumar                                                                                        #
 # Author Github: https://github.com/Darnel-K                                                                           #
 #                                                                                                                      #
@@ -56,7 +56,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
                 case "logic_meter":
                     entities_list.append(TesiraLogicMeterBlock(hub=hub, hubkey=hubkey, entity=entity))
                 case "logic_pulse":
-                    entities_list.append(TesiraLogicPulseBlock(hub=hub, hubkey=hubkey, entity=entity))
+                    entities_list.append(TesiraLogicPulseBlockActive(hub=hub, hubkey=hubkey, entity=entity))
+                case "logic_sequence":
+                    entities_list.append(TesiraLogicSequenceBlockActive(hub=hub, hubkey=hubkey, entity=entity))
                 case _:
                     _LOGGER.debug(
                         "Unsupported binary sensor block type '%s' for entity: %s",
@@ -209,8 +211,8 @@ class TesiraLogicMeterBlock(BinarySensorEntity):
             _LOGGER.debug("Update failed for %s: %s", self._attr_unique_id, e)
             self._attr_available = False
 
-class TesiraLogicPulseBlock(BinarySensorEntity):
-    """Expose a Tesira logic pulse block as a Home Assistant binary sensor entity."""
+class TesiraLogicPulseBlockActive(BinarySensorEntity):
+    """Expose a Tesira logic pulse block (Active) as a Home Assistant binary sensor entity."""
 
     def __init__(self, hub: TesiraHub, hubkey: str, entity: dict[str, Any]) -> None:
         self._hub = hub
@@ -221,6 +223,40 @@ class TesiraLogicPulseBlock(BinarySensorEntity):
         self._device_id = entity.get(DICT_KEYS["DEVICE_ID"])
         self._channel = int(entity.get(DICT_KEYS["ENTITY_BLOCK_CHANNEL"]))
         self._attr_name = f"Tesira Logic Pulse Block - Tag:{self._instance_tag} - Attr:Active - Chan:{self._channel} ({self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]})"
+        self._attr_unique_id = f"tesira_ttp_{self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]}_{self._block_type}_{self._instance_tag}_active_{self._channel}".lower()
+        self._attr_is_on: bool = False
+        self._attr_available = True
+
+    @property
+    def device_info(self):
+        return {DICT_KEYS["ENTITY_DEVICE_IDENTIFIERS"]: {(DOMAIN, self._device_id)}} if self._device_id != "None" else None
+
+    async def async_update(self) -> None:
+        try:
+            # Limits may differ between blocks/channels, so refresh before conversion each cycle.
+            resp = await self._hub.json(f"{self._instance_tag} get active {self._channel}")
+            active = resp["value"]
+            if active is not None:
+                self._attr_is_on = _coerce_bool(active)
+                self._attr_available = True
+            else:
+                raise ValueError(f"Could not parse active state from response: {resp!r}")
+        except Exception as e:
+            _LOGGER.debug("Update failed for %s: %s", self._attr_unique_id, e)
+            self._attr_available = False
+
+class TesiraLogicSequenceBlockActive(BinarySensorEntity):
+    """Expose a Tesira logic sequence block (Active) as a Home Assistant binary sensor entity."""
+
+    def __init__(self, hub: TesiraHub, hubkey: str, entity: dict[str, Any]) -> None:
+        self._hub = hub
+        self._hubkey = hubkey
+        self._entity = entity
+        self._instance_tag = entity.get(DICT_KEYS["ENTITY_BLOCK_INSTANCE_TAG"])
+        self._block_type = entity.get(DICT_KEYS["ENTITY_BLOCK_TYPE"])
+        self._device_id = entity.get(DICT_KEYS["DEVICE_ID"])
+        self._channel = int(entity.get(DICT_KEYS["ENTITY_BLOCK_CHANNEL"]))
+        self._attr_name = f"Tesira Logic Sequence Block - Tag:{self._instance_tag} - Attr:Active - Chan:{self._channel} ({self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]})"
         self._attr_unique_id = f"tesira_ttp_{self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]}_{self._block_type}_{self._instance_tag}_active_{self._channel}".lower()
         self._attr_is_on: bool = False
         self._attr_available = True

--- a/custom_components/tesira_ttp/binary_sensor.py
+++ b/custom_components/tesira_ttp/binary_sensor.py
@@ -1,8 +1,8 @@
 # #################################################################################################################### #
 # Filename: \custom_components\tesira_ttp\binary_sensor.py                                                             #
 # Repository: tesira_ttp                                                                                               #
-# Created Date: Saturday, March 28th 2026, 10:45:20 PM                                                                 #
-# Last Modified: Thursday, April 16th 2026, 11:33:40 PM                                                                #
+# Created Date: Monday, April 13th 2026, 12:33:01 AM                                                                   #
+# Last Modified: Tuesday, July 7th 2026, 11:06:42 PM                                                                   #
 # Original Author: Darnel Kumar                                                                                        #
 # Author Github: https://github.com/Darnel-K                                                                           #
 #                                                                                                                      #
@@ -37,6 +37,8 @@ from homeassistant.helpers import entity_registry as er
 
 from .const import DOMAIN, DICT_KEYS, DEFAULTS
 from .hub import TesiraHub
+from .util import _coerce_bool
+from typing import Any
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -47,11 +49,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     entities = copy.deepcopy(entry.options.get(DICT_KEYS["ENTITIES"], DEFAULTS["ENTITIES"]))
     entities_list = []
 
-    # Placeholder for future block-driven binary sensors from options entities.
-    # for block_type, item_list in entities.items():
-    #     for item in item_list:
-    #         if "binary_sensor" in item[DICT_KEYS["ENTITY_BLOCK_SUPPORTED_TYPES"]]:
-    #              pass
+    # Build entities from the dynamic options structure by block type.
+    for entity in entities:
+        if "binary_sensor" in entity[DICT_KEYS["ENTITY_BLOCK_SUPPORTED_TYPES"]]:
+            match entity[DICT_KEYS["ENTITY_BLOCK_TYPE"]]:
+                case "logic_meter":
+                    entities_list.append(TesiraLogicMeterBlock(hub=hub, hubkey=hubkey, entity=entity))
+                case _:
+                    _LOGGER.debug(
+                        "Unsupported binary sensor block type '%s' for entity: %s",
+                        entity.get(DICT_KEYS["ENTITY_BLOCK_TYPE"]),
+                        entity,
+                    )
 
 
     entities_list.append(TesiraHubConnBinarySensor(hub, hubkey))
@@ -136,3 +145,98 @@ class TesiraHubConnBinarySensor(BinarySensorEntity):
     async def async_update(self):
         # Reflect the client session state managed by TesiraHub/TesiraClient.
         self._attr_is_on = self._hub.is_connected
+
+class TesiraLogicMeterBlock(BinarySensorEntity):
+    """Expose a Tesira logic meter block as a Home Assistant binary sensor entity."""
+
+    def __init__(self, hub: TesiraHub, hubkey: str, entity: dict[str, Any]) -> None:
+        self._hub = hub
+        self._hubkey = hubkey
+        self._entity = entity
+        self._instance_tag = entity.get(DICT_KEYS["ENTITY_BLOCK_INSTANCE_TAG"])
+        self._block_type = entity.get(DICT_KEYS["ENTITY_BLOCK_TYPE"])
+        self._device_id = entity.get(DICT_KEYS["DEVICE_ID"])
+        self._channel = int(entity.get(DICT_KEYS["ENTITY_BLOCK_CHANNEL"]))
+        self._sub = entity.get(DICT_KEYS["ENTITY_BLOCK_SUBSCRIBE"])
+        self._attr_name = f"Tesira Logic Meter Block - Tag:{self._instance_tag} - Attr:State - Chan:{self._channel} ({self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]})"
+        self._attr_unique_id = f"tesira_ttp_{self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]}_{self._block_type}_{self._instance_tag}_state_{self._channel}".lower()
+        self._attr_is_on: bool = False
+        self._attr_available = True
+
+        if self._sub:
+            # Subscription mode pushes updates from the DSP, so polling is unnecessary.
+            self._attr_should_poll = False
+        else:
+            self._attr_should_poll = True
+
+    @property
+    def device_info(self):
+        return {DICT_KEYS["ENTITY_DEVICE_IDENTIFIERS"]: {(DOMAIN, self._device_id)}} if self._device_id != "None" else None
+
+    def _update_state_from_sub(self, data: dict) -> None:
+        state = data.get("value")
+        if state is not None:
+            self._attr_is_on = _coerce_bool(state)
+            self._attr_available = True
+            self._hass.loop.call_soon_threadsafe(self.async_write_ha_state)
+        else:
+            _LOGGER.warning("Received subscription update without state value: %s", data)
+
+    async def async_added_to_hass(self) -> None:
+        self._hass = self.hass
+        if self._sub:
+            # Prime state once before starting subscriptions to avoid an empty initial UI state.
+            await self.async_update()
+            await self._hub.subscribe(self._instance_tag, "state", self._channel, f"hass_switch_level_meter_{self._instance_tag}_{self._channel}", 100, self._update_state_from_sub)
+
+    async def async_will_remove_from_hass(self) -> None:
+        if self._sub:
+            await self._hub.unsubscribe(f"hass_switch_level_meter_{self._instance_tag}_{self._channel}")
+
+    async def async_update(self) -> None:
+        try:
+            # Limits may differ between blocks/channels, so refresh before conversion each cycle.
+            resp = await self._hub.json(f"{self._instance_tag} get state {self._channel}")
+            state = resp["value"]
+            if state is not None:
+                self._attr_is_on = _coerce_bool(state)
+                self._attr_available = True
+            else:
+                raise ValueError(f"Could not parse state from response: {resp!r}")
+        except Exception as e:
+            _LOGGER.debug("Update failed for %s: %s", self._attr_unique_id, e)
+            self._attr_available = False
+
+class TesiraLogicPulseBlock(BinarySensorEntity):
+    """Expose a Tesira logic pulse block as a Home Assistant binary sensor entity."""
+
+    def __init__(self, hub: TesiraHub, hubkey: str, entity: dict[str, Any]) -> None:
+        self._hub = hub
+        self._hubkey = hubkey
+        self._entity = entity
+        self._instance_tag = entity.get(DICT_KEYS["ENTITY_BLOCK_INSTANCE_TAG"])
+        self._block_type = entity.get(DICT_KEYS["ENTITY_BLOCK_TYPE"])
+        self._device_id = entity.get(DICT_KEYS["DEVICE_ID"])
+        self._channel = int(entity.get(DICT_KEYS["ENTITY_BLOCK_CHANNEL"]))
+        self._attr_name = f"Tesira Logic Pulse Block - Tag:{self._instance_tag} - Attr:Active - Chan:{self._channel} ({self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]})"
+        self._attr_unique_id = f"tesira_ttp_{self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]}_{self._block_type}_{self._instance_tag}_active_{self._channel}".lower()
+        self._attr_is_on: bool = False
+        self._attr_available = True
+
+    @property
+    def device_info(self):
+        return {DICT_KEYS["ENTITY_DEVICE_IDENTIFIERS"]: {(DOMAIN, self._device_id)}} if self._device_id != "None" else None
+
+    async def async_update(self) -> None:
+        try:
+            # Limits may differ between blocks/channels, so refresh before conversion each cycle.
+            resp = await self._hub.json(f"{self._instance_tag} get active {self._channel}")
+            state = resp["value"]
+            if state is not None:
+                self._attr_is_on = _coerce_bool(state)
+                self._attr_available = True
+            else:
+                raise ValueError(f"Could not parse active state from response: {resp!r}")
+        except Exception as e:
+            _LOGGER.debug("Update failed for %s: %s", self._attr_unique_id, e)
+            self._attr_available = False

--- a/custom_components/tesira_ttp/binary_sensor.py
+++ b/custom_components/tesira_ttp/binary_sensor.py
@@ -1,8 +1,8 @@
 # #################################################################################################################### #
 # Filename: \custom_components\tesira_ttp\binary_sensor.py                                                             #
 # Repository: tesira_ttp                                                                                               #
-# Created Date: Thursday, April 16th 2026, 11:44:37 PM                                                                 #
-# Last Modified: Tuesday, July 7th 2026, 11:08:47 PM                                                                   #
+# Created Date: Friday, May 8th 2026, 10:59:43 PM                                                                      #
+# Last Modified: Tuesday, July 7th 2026, 11:26:25 PM                                                                   #
 # Original Author: Darnel Kumar                                                                                        #
 # Author Github: https://github.com/Darnel-K                                                                           #
 #                                                                                                                      #
@@ -233,9 +233,9 @@ class TesiraLogicPulseBlock(BinarySensorEntity):
         try:
             # Limits may differ between blocks/channels, so refresh before conversion each cycle.
             resp = await self._hub.json(f"{self._instance_tag} get active {self._channel}")
-            state = resp["value"]
-            if state is not None:
-                self._attr_is_on = _coerce_bool(state)
+            active = resp["value"]
+            if active is not None:
+                self._attr_is_on = _coerce_bool(active)
                 self._attr_available = True
             else:
                 raise ValueError(f"Could not parse active state from response: {resp!r}")

--- a/custom_components/tesira_ttp/button.py
+++ b/custom_components/tesira_ttp/button.py
@@ -40,6 +40,8 @@ from .hub import TesiraHub
 _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities) -> None:
+    """Set up Tesira button entities for a config entry."""
+
     hubkey = entry.entry_id
     hub: TesiraHub = hass.data[DOMAIN][DICT_KEYS["DATA_HUBS"]][hubkey]
     entities = copy.deepcopy(entry.options.get(DICT_KEYS["ENTITIES"], DEFAULTS["ENTITIES"]))
@@ -55,6 +57,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
                     entities_list.append(TesiraLogicPulseBlockStop(hub=hub, hubkey=hubkey, entity=entity))
                 case "logic_sequence":
                     instance_tag = entity.get(DICT_KEYS["ENTITY_BLOCK_INSTANCE_TAG"])
+                    # Sequence start/stop operate on the block as a whole rather than a specific channel.
                     if instance_tag in logic_sequence_tags_added:
                         continue
                     logic_sequence_tags_added.add(instance_tag)

--- a/custom_components/tesira_ttp/button.py
+++ b/custom_components/tesira_ttp/button.py
@@ -1,8 +1,8 @@
 # #################################################################################################################### #
 # Filename: \custom_components\tesira_ttp\button.py                                                                    #
 # Repository: tesira_ttp                                                                                               #
-# Created Date: Thursday, April 16th 2026, 11:44:37 PM                                                                 #
-# Last Modified: Wednesday, July 8th 2026, 12:00:51 AM                                                                 #
+# Created Date: Tuesday, July 7th 2026, 11:50:58 PM                                                                    #
+# Last Modified: Wednesday, July 8th 2026, 12:17:50 AM                                                                 #
 # Original Author: Darnel Kumar                                                                                        #
 # Author Github: https://github.com/Darnel-K                                                                           #
 #                                                                                                                      #
@@ -44,6 +44,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     hub: TesiraHub = hass.data[DOMAIN][DICT_KEYS["DATA_HUBS"]][hubkey]
     entities = copy.deepcopy(entry.options.get(DICT_KEYS["ENTITIES"], DEFAULTS["ENTITIES"]))
     entities_list = []
+    logic_sequence_tags_added: set[str | None] = set()
 
     # Build entities from the dynamic options structure by block type.
     for entity in entities:
@@ -52,6 +53,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
                 case "logic_pulse":
                     entities_list.append(TesiraLogicPulseBlockStart(hub=hub, hubkey=hubkey, entity=entity))
                     entities_list.append(TesiraLogicPulseBlockStop(hub=hub, hubkey=hubkey, entity=entity))
+                case "logic_sequence":
+                    instance_tag = entity.get(DICT_KEYS["ENTITY_BLOCK_INSTANCE_TAG"])
+                    if instance_tag in logic_sequence_tags_added:
+                        continue
+                    logic_sequence_tags_added.add(instance_tag)
+                    entities_list.append(TesiraLogicSequenceBlockStart(hub=hub, hubkey=hubkey, entity=entity))
+                    entities_list.append(TesiraLogicSequenceBlockStop(hub=hub, hubkey=hubkey, entity=entity))
                 case _:
                     _LOGGER.debug(
                         "Unsupported button block type '%s' for entity: %s",
@@ -119,6 +127,60 @@ class TesiraLogicPulseBlockStop(ButtonEntity):
         try:
             # Limits may differ between blocks/channels, so refresh before conversion each cycle.
             await self._hub.json(f"{self._instance_tag} stopPulse {self._channel}")
+        except Exception as e:
+            _LOGGER.debug("Button press failed for %s: %s", self._attr_unique_id, e)
+            self._attr_available = False
+
+class TesiraLogicSequenceBlockStart(ButtonEntity):
+    """Expose a Tesira logic sequence block (Start) as a Home Assistant button entity."""
+
+    def __init__(self, hub: TesiraHub, hubkey: str, entity: dict[str, Any]) -> None:
+        self._hub = hub
+        self._hubkey = hubkey
+        self._entity = entity
+        self._instance_tag = entity.get(DICT_KEYS["ENTITY_BLOCK_INSTANCE_TAG"])
+        self._block_type = entity.get(DICT_KEYS["ENTITY_BLOCK_TYPE"])
+        self._device_id = entity.get(DICT_KEYS["DEVICE_ID"])
+        self._channel = int(entity.get(DICT_KEYS["ENTITY_BLOCK_CHANNEL"]))
+        self._attr_name = f"Tesira Logic Sequence Block - Tag:{self._instance_tag} - Attr:Start ({self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]})"
+        self._attr_unique_id = f"tesira_ttp_{self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]}_{self._block_type}_{self._instance_tag}_start".lower()
+        self._attr_available = True
+
+    @property
+    def device_info(self):
+        return {DICT_KEYS["ENTITY_DEVICE_IDENTIFIERS"]: {(DOMAIN, self._device_id)}} if self._device_id != "None" else None
+
+    async def async_press(self) -> None:
+        try:
+            # Limits may differ between blocks/channels, so refresh before conversion each cycle.
+            await self._hub.json(f"{self._instance_tag} startSequence")
+        except Exception as e:
+            _LOGGER.debug("Button press failed for %s: %s", self._attr_unique_id, e)
+            self._attr_available = False
+
+class TesiraLogicSequenceBlockStop(ButtonEntity):
+    """Expose a Tesira logic sequence block (Stop) as a Home Assistant button entity."""
+
+    def __init__(self, hub: TesiraHub, hubkey: str, entity: dict[str, Any]) -> None:
+        self._hub = hub
+        self._hubkey = hubkey
+        self._entity = entity
+        self._instance_tag = entity.get(DICT_KEYS["ENTITY_BLOCK_INSTANCE_TAG"])
+        self._block_type = entity.get(DICT_KEYS["ENTITY_BLOCK_TYPE"])
+        self._device_id = entity.get(DICT_KEYS["DEVICE_ID"])
+        self._channel = int(entity.get(DICT_KEYS["ENTITY_BLOCK_CHANNEL"]))
+        self._attr_name = f"Tesira Logic Sequence Block - Tag:{self._instance_tag} - Attr:Stop ({self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]})"
+        self._attr_unique_id = f"tesira_ttp_{self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]}_{self._block_type}_{self._instance_tag}_stop".lower()
+        self._attr_available = True
+
+    @property
+    def device_info(self):
+        return {DICT_KEYS["ENTITY_DEVICE_IDENTIFIERS"]: {(DOMAIN, self._device_id)}} if self._device_id != "None" else None
+
+    async def async_press(self) -> None:
+        try:
+            # Limits may differ between blocks/channels, so refresh before conversion each cycle.
+            await self._hub.json(f"{self._instance_tag} stopSequence")
         except Exception as e:
             _LOGGER.debug("Button press failed for %s: %s", self._attr_unique_id, e)
             self._attr_available = False

--- a/custom_components/tesira_ttp/button.py
+++ b/custom_components/tesira_ttp/button.py
@@ -1,0 +1,124 @@
+# #################################################################################################################### #
+# Filename: \custom_components\tesira_ttp\button.py                                                                    #
+# Repository: tesira_ttp                                                                                               #
+# Created Date: Thursday, April 16th 2026, 11:44:37 PM                                                                 #
+# Last Modified: Wednesday, July 8th 2026, 12:00:51 AM                                                                 #
+# Original Author: Darnel Kumar                                                                                        #
+# Author Github: https://github.com/Darnel-K                                                                           #
+#                                                                                                                      #
+# License: GNU Affero General Public License v3.0 only - https://www.gnu.org/licenses/agpl.txt                         #
+# Copyright (c) 2026 Darnel Kumar                                                                                      #
+#                                                                                                                      #
+# This program is free software: you can redistribute it and/or modify                                                 #
+# it under the terms of the GNU Affero General Public License as published                                             #
+# by the Free Software Foundation, either version 3 of the License, or                                                 #
+# (at your option) any later version.                                                                                  #
+#                                                                                                                      #
+# This program is distributed in the hope that it will be useful,                                                      #
+# but WITHOUT ANY WARRANTY; without even the implied warranty of                                                       #
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                                                        #
+# GNU Affero General Public License for more details.                                                                  #
+#                                                                                                                      #
+# You should have received a copy of the GNU Affero General Public License                                             #
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.                                               #
+# #################################################################################################################### #
+from __future__ import annotations
+
+import logging
+import copy
+from typing import Any
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.components.button import ButtonEntity, ButtonDeviceClass
+from homeassistant.helpers import entity_registry as er
+
+from .const import DOMAIN, DICT_KEYS, DEFAULTS
+from .hub import TesiraHub
+
+
+_LOGGER = logging.getLogger(__name__)
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities) -> None:
+    hubkey = entry.entry_id
+    hub: TesiraHub = hass.data[DOMAIN][DICT_KEYS["DATA_HUBS"]][hubkey]
+    entities = copy.deepcopy(entry.options.get(DICT_KEYS["ENTITIES"], DEFAULTS["ENTITIES"]))
+    entities_list = []
+
+    # Build entities from the dynamic options structure by block type.
+    for entity in entities:
+        if "button" in entity[DICT_KEYS["ENTITY_BLOCK_SUPPORTED_TYPES"]]:
+            match entity[DICT_KEYS["ENTITY_BLOCK_TYPE"]]:
+                case "logic_pulse":
+                    entities_list.append(TesiraLogicPulseBlockStart(hub=hub, hubkey=hubkey, entity=entity))
+                    entities_list.append(TesiraLogicPulseBlockStop(hub=hub, hubkey=hubkey, entity=entity))
+                case _:
+                    _LOGGER.debug(
+                        "Unsupported button block type '%s' for entity: %s",
+                        entity.get(DICT_KEYS["ENTITY_BLOCK_TYPE"]),
+                        entity,
+                    )
+
+
+    # Remove stale button entities no longer present in the current config.
+    entity_registry = er.async_get(hass)
+    expected_ids = {e.unique_id for e in entities_list}
+    for entity_entry in er.async_entries_for_config_entry(entity_registry, entry.entry_id):
+        if entity_entry.domain == "button" and entity_entry.unique_id not in expected_ids:
+            entity_registry.async_remove(entity_entry.entity_id)
+
+    async_add_entities(entities_list, update_before_add=True)
+
+class TesiraLogicPulseBlockStart(ButtonEntity):
+    """Expose a Tesira logic pulse block (Start) as a Home Assistant button entity."""
+
+    def __init__(self, hub: TesiraHub, hubkey: str, entity: dict[str, Any]) -> None:
+        self._hub = hub
+        self._hubkey = hubkey
+        self._entity = entity
+        self._instance_tag = entity.get(DICT_KEYS["ENTITY_BLOCK_INSTANCE_TAG"])
+        self._block_type = entity.get(DICT_KEYS["ENTITY_BLOCK_TYPE"])
+        self._device_id = entity.get(DICT_KEYS["DEVICE_ID"])
+        self._channel = int(entity.get(DICT_KEYS["ENTITY_BLOCK_CHANNEL"]))
+        self._attr_name = f"Tesira Logic Pulse Block - Tag:{self._instance_tag} - Attr:Start - Chan:{self._channel} ({self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]})"
+        self._attr_unique_id = f"tesira_ttp_{self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]}_{self._block_type}_{self._instance_tag}_start_{self._channel}".lower()
+        self._attr_available = True
+
+    @property
+    def device_info(self):
+        return {DICT_KEYS["ENTITY_DEVICE_IDENTIFIERS"]: {(DOMAIN, self._device_id)}} if self._device_id != "None" else None
+
+    async def async_press(self) -> None:
+        try:
+            # Limits may differ between blocks/channels, so refresh before conversion each cycle.
+            await self._hub.json(f"{self._instance_tag} startPulse {self._channel}")
+        except Exception as e:
+            _LOGGER.debug("Button press failed for %s: %s", self._attr_unique_id, e)
+            self._attr_available = False
+
+class TesiraLogicPulseBlockStop(ButtonEntity):
+    """Expose a Tesira logic pulse block (Stop) as a Home Assistant button entity."""
+
+    def __init__(self, hub: TesiraHub, hubkey: str, entity: dict[str, Any]) -> None:
+        self._hub = hub
+        self._hubkey = hubkey
+        self._entity = entity
+        self._instance_tag = entity.get(DICT_KEYS["ENTITY_BLOCK_INSTANCE_TAG"])
+        self._block_type = entity.get(DICT_KEYS["ENTITY_BLOCK_TYPE"])
+        self._device_id = entity.get(DICT_KEYS["DEVICE_ID"])
+        self._channel = int(entity.get(DICT_KEYS["ENTITY_BLOCK_CHANNEL"]))
+        self._attr_name = f"Tesira Logic Pulse Block - Tag:{self._instance_tag} - Attr:Stop - Chan:{self._channel} ({self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]})"
+        self._attr_unique_id = f"tesira_ttp_{self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]}_{self._block_type}_{self._instance_tag}_stop_{self._channel}".lower()
+        self._attr_available = True
+
+    @property
+    def device_info(self):
+        return {DICT_KEYS["ENTITY_DEVICE_IDENTIFIERS"]: {(DOMAIN, self._device_id)}} if self._device_id != "None" else None
+
+    async def async_press(self) -> None:
+        try:
+            # Limits may differ between blocks/channels, so refresh before conversion each cycle.
+            await self._hub.json(f"{self._instance_tag} stopPulse {self._channel}")
+        except Exception as e:
+            _LOGGER.debug("Button press failed for %s: %s", self._attr_unique_id, e)
+            self._attr_available = False

--- a/custom_components/tesira_ttp/const.py
+++ b/custom_components/tesira_ttp/const.py
@@ -1,8 +1,8 @@
 # #################################################################################################################### #
 # Filename: \custom_components\tesira_ttp\const.py                                                                     #
 # Repository: tesira_ttp                                                                                               #
-# Created Date: Monday, April 13th 2026, 12:33:01 AM                                                                   #
-# Last Modified: Saturday, May 9th 2026, 12:14:05 AM                                                                   #
+# Created Date: Thursday, March 19th 2026, 12:56:52 AM                                                                 #
+# Last Modified: Tuesday, July 7th 2026, 11:03:40 PM                                                                   #
 # Original Author: Darnel Kumar                                                                                        #
 # Author Github: https://github.com/Darnel-K                                                                           #
 #                                                                                                                      #
@@ -140,6 +140,31 @@ BLOCK_SCHEMA_DATA = {
         },
         DICT_KEYS["ENTITY_BLOCK_SUPPORTED_TYPES"]: ["switch", "number"],
         DICT_KEYS["ENTITY_BLOCK_FIELDS"]: [DICT_KEYS["DEVICE_ID"], DICT_KEYS["ENTITY_BLOCK_INSTANCE_TAG"], DICT_KEYS["ENTITY_BLOCK_CHANNEL"], DICT_KEYS["ENTITY_MIN_VALUE"], DICT_KEYS["ENTITY_MAX_VALUE"]]
+    },
+    "logic_input": {
+        "label": "Logic Input",
+        DICT_KEYS["ENTITY_BLOCK_SUPPORTED_TYPES"]: ["switch"],
+        DICT_KEYS["ENTITY_BLOCK_FIELDS"]: [DICT_KEYS["DEVICE_ID"], DICT_KEYS["ENTITY_BLOCK_INSTANCE_TAG"], DICT_KEYS["ENTITY_BLOCK_CHANNEL"]]
+    },
+    "logic_meter": {
+        "label": "Logic Meter",
+        DICT_KEYS["ENTITY_BLOCK_SUPPORTED_TYPES"]: ["binary_sensor"],
+        DICT_KEYS["ENTITY_BLOCK_FIELDS"]: [DICT_KEYS["DEVICE_ID"], DICT_KEYS["ENTITY_BLOCK_INSTANCE_TAG"], DICT_KEYS["ENTITY_BLOCK_CHANNEL"], DICT_KEYS["ENTITY_BLOCK_SUBSCRIBE"]]
+    },
+    "logic_output": {
+        "label": "Logic Output",
+        DICT_KEYS["ENTITY_BLOCK_SUPPORTED_TYPES"]: ["switch"],
+        DICT_KEYS["ENTITY_BLOCK_FIELDS"]: [DICT_KEYS["DEVICE_ID"], DICT_KEYS["ENTITY_BLOCK_INSTANCE_TAG"], DICT_KEYS["ENTITY_BLOCK_CHANNEL"]]
+    },
+    "logic_selector": {
+        "label": "Logic Selector",
+        DICT_KEYS["ENTITY_BLOCK_SUPPORTED_TYPES"]: ["switch"],
+        DICT_KEYS["ENTITY_BLOCK_FIELDS"]: [DICT_KEYS["DEVICE_ID"], DICT_KEYS["ENTITY_BLOCK_INSTANCE_TAG"], DICT_KEYS["ENTITY_BLOCK_CHANNEL"], DICT_KEYS["ENTITY_BLOCK_SUBSCRIBE"]]
+    },
+    "logic_pulse": {
+        "label": "Logic Pulse",
+        DICT_KEYS["ENTITY_BLOCK_SUPPORTED_TYPES"]: ["binary_sensor"],
+        DICT_KEYS["ENTITY_BLOCK_FIELDS"]: [DICT_KEYS["DEVICE_ID"], DICT_KEYS["ENTITY_BLOCK_INSTANCE_TAG"], DICT_KEYS["ENTITY_BLOCK_CHANNEL"]]
     }
 }
 

--- a/custom_components/tesira_ttp/const.py
+++ b/custom_components/tesira_ttp/const.py
@@ -1,8 +1,8 @@
 # #################################################################################################################### #
 # Filename: \custom_components\tesira_ttp\const.py                                                                     #
 # Repository: tesira_ttp                                                                                               #
-# Created Date: Monday, April 13th 2026, 12:33:01 AM                                                                   #
-# Last Modified: Wednesday, July 8th 2026, 12:05:46 AM                                                                 #
+# Created Date: Tuesday, July 7th 2026, 11:50:58 PM                                                                    #
+# Last Modified: Wednesday, July 8th 2026, 12:36:42 AM                                                                 #
 # Original Author: Darnel Kumar                                                                                        #
 # Author Github: https://github.com/Darnel-K                                                                           #
 #                                                                                                                      #

--- a/custom_components/tesira_ttp/const.py
+++ b/custom_components/tesira_ttp/const.py
@@ -1,8 +1,8 @@
 # #################################################################################################################### #
 # Filename: \custom_components\tesira_ttp\const.py                                                                     #
 # Repository: tesira_ttp                                                                                               #
-# Created Date: Saturday, March 28th 2026, 10:45:20 PM                                                                 #
-# Last Modified: Saturday, May 2nd 2026, 10:40:35 PM                                                                   #
+# Created Date: Thursday, March 19th 2026, 12:56:52 AM                                                                 #
+# Last Modified: Friday, May 8th 2026, 10:36:42 PM                                                                     #
 # Original Author: Darnel Kumar                                                                                        #
 # Author Github: https://github.com/Darnel-K                                                                           #
 #                                                                                                                      #
@@ -107,6 +107,11 @@ BLOCK_SCHEMA_DATA = {
     },
     "logic_state": {
         "label": "Logic State",
+        DICT_KEYS["ENTITY_BLOCK_SUPPORTED_TYPES"]: ["switch"],
+        DICT_KEYS["ENTITY_BLOCK_FIELDS"]: [DICT_KEYS["DEVICE_ID"], DICT_KEYS["ENTITY_BLOCK_INSTANCE_TAG"], DICT_KEYS["ENTITY_BLOCK_CHANNEL"], DICT_KEYS["ENTITY_BLOCK_SUBSCRIBE"]]
+    },
+    "flip_flop": {
+        "label": "Flip Flop",
         DICT_KEYS["ENTITY_BLOCK_SUPPORTED_TYPES"]: ["switch"],
         DICT_KEYS["ENTITY_BLOCK_FIELDS"]: [DICT_KEYS["DEVICE_ID"], DICT_KEYS["ENTITY_BLOCK_INSTANCE_TAG"], DICT_KEYS["ENTITY_BLOCK_CHANNEL"], DICT_KEYS["ENTITY_BLOCK_SUBSCRIBE"]]
     }

--- a/custom_components/tesira_ttp/const.py
+++ b/custom_components/tesira_ttp/const.py
@@ -1,8 +1,8 @@
 # #################################################################################################################### #
 # Filename: \custom_components\tesira_ttp\const.py                                                                     #
 # Repository: tesira_ttp                                                                                               #
-# Created Date: Thursday, March 19th 2026, 12:56:52 AM                                                                 #
-# Last Modified: Tuesday, July 7th 2026, 11:03:40 PM                                                                   #
+# Created Date: Thursday, April 16th 2026, 11:44:37 PM                                                                 #
+# Last Modified: Tuesday, July 7th 2026, 11:08:47 PM                                                                   #
 # Original Author: Darnel Kumar                                                                                        #
 # Author Github: https://github.com/Darnel-K                                                                           #
 #                                                                                                                      #
@@ -163,7 +163,7 @@ BLOCK_SCHEMA_DATA = {
     },
     "logic_pulse": {
         "label": "Logic Pulse",
-        DICT_KEYS["ENTITY_BLOCK_SUPPORTED_TYPES"]: ["binary_sensor"],
+        DICT_KEYS["ENTITY_BLOCK_SUPPORTED_TYPES"]: ["binary_sensor", "switch"],
         DICT_KEYS["ENTITY_BLOCK_FIELDS"]: [DICT_KEYS["DEVICE_ID"], DICT_KEYS["ENTITY_BLOCK_INSTANCE_TAG"], DICT_KEYS["ENTITY_BLOCK_CHANNEL"]]
     }
 }

--- a/custom_components/tesira_ttp/const.py
+++ b/custom_components/tesira_ttp/const.py
@@ -2,7 +2,7 @@
 # Filename: \custom_components\tesira_ttp\const.py                                                                     #
 # Repository: tesira_ttp                                                                                               #
 # Created Date: Thursday, March 19th 2026, 12:56:52 AM                                                                 #
-# Last Modified: Tuesday, July 7th 2026, 11:18:16 PM                                                                   #
+# Last Modified: Wednesday, July 8th 2026, 12:03:18 AM                                                                 #
 # Original Author: Darnel Kumar                                                                                        #
 # Author Github: https://github.com/Darnel-K                                                                           #
 #                                                                                                                      #
@@ -27,7 +27,7 @@ from __future__ import annotations
 from homeassistant.const import Platform
 
 DOMAIN = "tesira_ttp"
-PLATFORMS: list[Platform] = [Platform.MEDIA_PLAYER, Platform.BINARY_SENSOR, Platform.SWITCH, Platform.NUMBER]
+PLATFORMS: list[Platform] = [Platform.MEDIA_PLAYER, Platform.BINARY_SENSOR, Platform.SWITCH, Platform.NUMBER, Platform.BUTTON]
 
 DICT_KEYS = {
     "DATA_HUBS": "hubs",
@@ -134,9 +134,8 @@ BLOCK_SCHEMA_DATA = {
     "logic_delay": {
         "label": "Logic Delay",
         DICT_KEYS["ENTITY_BLOCK_FIELD_OPTIONS"]: {
-            DICT_KEYS["ENTITY_MIN_VALUE"]: {"min": 0, "max": 60000},
-            DICT_KEYS["ENTITY_MAX_VALUE"]: {"min": 0, "max": 60000},
-            DICT_KEYS["ENTITY_FIELD_TYPE_OVERRIDE"]: "integer"
+            DICT_KEYS["ENTITY_MIN_VALUE"]: {"min": 0, "max": 60000, DICT_KEYS["ENTITY_FIELD_TYPE_OVERRIDE"]: "integer"},
+            DICT_KEYS["ENTITY_MAX_VALUE"]: {"min": 0, "max": 60000, DICT_KEYS["ENTITY_FIELD_TYPE_OVERRIDE"]: "integer"}
         },
         DICT_KEYS["ENTITY_BLOCK_SUPPORTED_TYPES"]: ["switch", "number"],
         DICT_KEYS["ENTITY_BLOCK_FIELDS"]: [DICT_KEYS["DEVICE_ID"], DICT_KEYS["ENTITY_BLOCK_INSTANCE_TAG"], DICT_KEYS["ENTITY_BLOCK_CHANNEL"], DICT_KEYS["ENTITY_MIN_VALUE"], DICT_KEYS["ENTITY_MAX_VALUE"]]
@@ -164,12 +163,11 @@ BLOCK_SCHEMA_DATA = {
     "logic_pulse": {
         "label": "Logic Pulse",
         DICT_KEYS["ENTITY_BLOCK_FIELD_OPTIONS"]: {
-            DICT_KEYS["ENTITY_MIN_VALUE"]: {"min": 1000, "max": 60000},
-            DICT_KEYS["ENTITY_MAX_VALUE"]: {"min": 1000, "max": 60000},
-            DICT_KEYS["ENTITY_FIELD_TYPE_OVERRIDE"]: "integer"
+            DICT_KEYS["ENTITY_MIN_VALUE"]: {"min": 1, "max": 60000, DICT_KEYS["ENTITY_FIELD_TYPE_OVERRIDE"]: "integer"},
+            DICT_KEYS["ENTITY_MAX_VALUE"]: {"min": 1, "max": 60000, DICT_KEYS["ENTITY_FIELD_TYPE_OVERRIDE"]: "integer"}
         },
-        DICT_KEYS["ENTITY_BLOCK_SUPPORTED_TYPES"]: ["binary_sensor", "switch", "number"],
-        DICT_KEYS["ENTITY_BLOCK_FIELDS"]: [DICT_KEYS["DEVICE_ID"], DICT_KEYS["ENTITY_BLOCK_INSTANCE_TAG"], DICT_KEYS["ENTITY_BLOCK_CHANNEL"]]
+        DICT_KEYS["ENTITY_BLOCK_SUPPORTED_TYPES"]: ["binary_sensor", "switch", "number", "button"],
+        DICT_KEYS["ENTITY_BLOCK_FIELDS"]: [DICT_KEYS["DEVICE_ID"], DICT_KEYS["ENTITY_BLOCK_INSTANCE_TAG"], DICT_KEYS["ENTITY_BLOCK_CHANNEL"], DICT_KEYS["ENTITY_MIN_VALUE"], DICT_KEYS["ENTITY_MAX_VALUE"]]
     }
 }
 

--- a/custom_components/tesira_ttp/const.py
+++ b/custom_components/tesira_ttp/const.py
@@ -1,8 +1,8 @@
 # #################################################################################################################### #
 # Filename: \custom_components\tesira_ttp\const.py                                                                     #
 # Repository: tesira_ttp                                                                                               #
-# Created Date: Thursday, March 19th 2026, 12:56:52 AM                                                                 #
-# Last Modified: Friday, May 8th 2026, 10:36:42 PM                                                                     #
+# Created Date: Monday, April 13th 2026, 12:33:01 AM                                                                   #
+# Last Modified: Saturday, May 9th 2026, 12:14:05 AM                                                                   #
 # Original Author: Darnel Kumar                                                                                        #
 # Author Github: https://github.com/Darnel-K                                                                           #
 #                                                                                                                      #
@@ -27,7 +27,7 @@ from __future__ import annotations
 from homeassistant.const import Platform
 
 DOMAIN = "tesira_ttp"
-PLATFORMS: list[Platform] = [Platform.MEDIA_PLAYER, Platform.BINARY_SENSOR, Platform.SWITCH]
+PLATFORMS: list[Platform] = [Platform.MEDIA_PLAYER, Platform.BINARY_SENSOR, Platform.SWITCH, Platform.NUMBER]
 
 DICT_KEYS = {
     "DATA_HUBS": "hubs",
@@ -52,10 +52,14 @@ DICT_KEYS = {
     "EDIT_ID": "edit_id",
     "ENTITY_BLOCK_TYPE": "block_type",
     "ENTITY_BLOCK_FIELDS": "fields",
+    "ENTITY_BLOCK_FIELD_OPTIONS": "field_options",
     "ENTITY_BLOCK_SUPPORTED_TYPES": "supported_entity_types",
     "ENTITY_BLOCK_INSTANCE_TAG": "instance_tag",
     "ENTITY_BLOCK_CHANNEL": "channel",
-    "ENTITY_BLOCK_SUBSCRIBE": "subscribe"
+    "ENTITY_BLOCK_SUBSCRIBE": "subscribe",
+    "ENTITY_MIN_VALUE": "min_value",
+    "ENTITY_MAX_VALUE": "max_value",
+    "ENTITY_FIELD_TYPE_OVERRIDE": "field_type_override"
 }
 
 STEP_IDS = {}
@@ -91,6 +95,18 @@ SCHEMA_FIELDS = {
         "default": False,
         "required": True
     },
+    DICT_KEYS["ENTITY_MIN_VALUE"]: {
+        "label": "Minimum Value",
+        "type": "float",
+        "default": 0.0,
+        "required": True
+    },
+    DICT_KEYS["ENTITY_MAX_VALUE"]: {
+        "label": "Maximum Value",
+        "type": "float",
+        "default": 0.0,
+        "required": True
+    },
     DICT_KEYS["DEVICE_ID"]: {
         "label": "Device",
         "type": "device_list",
@@ -114,6 +130,16 @@ BLOCK_SCHEMA_DATA = {
         "label": "Flip Flop",
         DICT_KEYS["ENTITY_BLOCK_SUPPORTED_TYPES"]: ["switch"],
         DICT_KEYS["ENTITY_BLOCK_FIELDS"]: [DICT_KEYS["DEVICE_ID"], DICT_KEYS["ENTITY_BLOCK_INSTANCE_TAG"], DICT_KEYS["ENTITY_BLOCK_CHANNEL"], DICT_KEYS["ENTITY_BLOCK_SUBSCRIBE"]]
+    },
+    "logic_delay": {
+        "label": "Logic Delay",
+        DICT_KEYS["ENTITY_BLOCK_FIELD_OPTIONS"]: {
+            DICT_KEYS["ENTITY_MIN_VALUE"]: {"min": 0, "max": 60000},
+            DICT_KEYS["ENTITY_MAX_VALUE"]: {"min": 0, "max": 60000},
+            DICT_KEYS["ENTITY_FIELD_TYPE_OVERRIDE"]: "integer"
+        },
+        DICT_KEYS["ENTITY_BLOCK_SUPPORTED_TYPES"]: ["switch", "number"],
+        DICT_KEYS["ENTITY_BLOCK_FIELDS"]: [DICT_KEYS["DEVICE_ID"], DICT_KEYS["ENTITY_BLOCK_INSTANCE_TAG"], DICT_KEYS["ENTITY_BLOCK_CHANNEL"], DICT_KEYS["ENTITY_MIN_VALUE"], DICT_KEYS["ENTITY_MAX_VALUE"]]
     }
 }
 

--- a/custom_components/tesira_ttp/const.py
+++ b/custom_components/tesira_ttp/const.py
@@ -1,8 +1,8 @@
 # #################################################################################################################### #
 # Filename: \custom_components\tesira_ttp\const.py                                                                     #
 # Repository: tesira_ttp                                                                                               #
-# Created Date: Thursday, March 19th 2026, 12:56:52 AM                                                                 #
-# Last Modified: Wednesday, July 8th 2026, 12:03:18 AM                                                                 #
+# Created Date: Monday, April 13th 2026, 12:33:01 AM                                                                   #
+# Last Modified: Wednesday, July 8th 2026, 12:05:46 AM                                                                 #
 # Original Author: Darnel Kumar                                                                                        #
 # Author Github: https://github.com/Darnel-K                                                                           #
 #                                                                                                                      #
@@ -162,6 +162,15 @@ BLOCK_SCHEMA_DATA = {
     },
     "logic_pulse": {
         "label": "Logic Pulse",
+        DICT_KEYS["ENTITY_BLOCK_FIELD_OPTIONS"]: {
+            DICT_KEYS["ENTITY_MIN_VALUE"]: {"min": 1, "max": 60000, DICT_KEYS["ENTITY_FIELD_TYPE_OVERRIDE"]: "integer"},
+            DICT_KEYS["ENTITY_MAX_VALUE"]: {"min": 1, "max": 60000, DICT_KEYS["ENTITY_FIELD_TYPE_OVERRIDE"]: "integer"}
+        },
+        DICT_KEYS["ENTITY_BLOCK_SUPPORTED_TYPES"]: ["binary_sensor", "switch", "number", "button"],
+        DICT_KEYS["ENTITY_BLOCK_FIELDS"]: [DICT_KEYS["DEVICE_ID"], DICT_KEYS["ENTITY_BLOCK_INSTANCE_TAG"], DICT_KEYS["ENTITY_BLOCK_CHANNEL"], DICT_KEYS["ENTITY_MIN_VALUE"], DICT_KEYS["ENTITY_MAX_VALUE"]]
+    },
+    "logic_sequence": {
+        "label": "Logic Sequence",
         DICT_KEYS["ENTITY_BLOCK_FIELD_OPTIONS"]: {
             DICT_KEYS["ENTITY_MIN_VALUE"]: {"min": 1, "max": 60000, DICT_KEYS["ENTITY_FIELD_TYPE_OVERRIDE"]: "integer"},
             DICT_KEYS["ENTITY_MAX_VALUE"]: {"min": 1, "max": 60000, DICT_KEYS["ENTITY_FIELD_TYPE_OVERRIDE"]: "integer"}

--- a/custom_components/tesira_ttp/const.py
+++ b/custom_components/tesira_ttp/const.py
@@ -1,8 +1,8 @@
 # #################################################################################################################### #
 # Filename: \custom_components\tesira_ttp\const.py                                                                     #
 # Repository: tesira_ttp                                                                                               #
-# Created Date: Thursday, April 16th 2026, 11:44:37 PM                                                                 #
-# Last Modified: Tuesday, July 7th 2026, 11:08:47 PM                                                                   #
+# Created Date: Thursday, March 19th 2026, 12:56:52 AM                                                                 #
+# Last Modified: Tuesday, July 7th 2026, 11:18:16 PM                                                                   #
 # Original Author: Darnel Kumar                                                                                        #
 # Author Github: https://github.com/Darnel-K                                                                           #
 #                                                                                                                      #
@@ -163,7 +163,12 @@ BLOCK_SCHEMA_DATA = {
     },
     "logic_pulse": {
         "label": "Logic Pulse",
-        DICT_KEYS["ENTITY_BLOCK_SUPPORTED_TYPES"]: ["binary_sensor", "switch"],
+        DICT_KEYS["ENTITY_BLOCK_FIELD_OPTIONS"]: {
+            DICT_KEYS["ENTITY_MIN_VALUE"]: {"min": 1000, "max": 60000},
+            DICT_KEYS["ENTITY_MAX_VALUE"]: {"min": 1000, "max": 60000},
+            DICT_KEYS["ENTITY_FIELD_TYPE_OVERRIDE"]: "integer"
+        },
+        DICT_KEYS["ENTITY_BLOCK_SUPPORTED_TYPES"]: ["binary_sensor", "switch", "number"],
         DICT_KEYS["ENTITY_BLOCK_FIELDS"]: [DICT_KEYS["DEVICE_ID"], DICT_KEYS["ENTITY_BLOCK_INSTANCE_TAG"], DICT_KEYS["ENTITY_BLOCK_CHANNEL"]]
     }
 }

--- a/custom_components/tesira_ttp/manifest.json
+++ b/custom_components/tesira_ttp/manifest.json
@@ -19,5 +19,5 @@
         "fido2>=1.2.0",
         "prompt_toolkit>=3.0.52"
     ],
-    "version": "0.13.0"
+    "version": "0.14.0"
 }

--- a/custom_components/tesira_ttp/number.py
+++ b/custom_components/tesira_ttp/number.py
@@ -1,0 +1,168 @@
+# #################################################################################################################### #
+# Filename: \custom_components\tesira_ttp\number.py                                                                    #
+# Repository: tesira_ttp                                                                                               #
+# Created Date: Friday, May 8th 2026, 10:59:43 PM                                                                      #
+# Last Modified: Friday, May 8th 2026, 11:29:56 PM                                                                     #
+# Original Author: Darnel Kumar                                                                                        #
+# Author Github: https://github.com/Darnel-K                                                                           #
+#                                                                                                                      #
+# License: GNU Affero General Public License v3.0 only - https://www.gnu.org/licenses/agpl.txt                         #
+# Copyright (c) 2026 Darnel Kumar                                                                                      #
+#                                                                                                                      #
+# This program is free software: you can redistribute it and/or modify                                                 #
+# it under the terms of the GNU Affero General Public License as published                                             #
+# by the Free Software Foundation, either version 3 of the License, or                                                 #
+# (at your option) any later version.                                                                                  #
+#                                                                                                                      #
+# This program is distributed in the hope that it will be useful,                                                      #
+# but WITHOUT ANY WARRANTY; without even the implied warranty of                                                       #
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                                                        #
+# GNU Affero General Public License for more details.                                                                  #
+#                                                                                                                      #
+# You should have received a copy of the GNU Affero General Public License                                             #
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.                                               #
+# #################################################################################################################### #
+from __future__ import annotations
+
+import logging
+import copy
+from typing import Any
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.components.number import NumberEntity, NumberDeviceClass
+from homeassistant.helpers import entity_registry as er
+
+from .const import DOMAIN, DICT_KEYS, DEFAULTS
+from .hub import TesiraHub
+
+
+_LOGGER = logging.getLogger(__name__)
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities) -> None:
+    hubkey = entry.entry_id
+    hub: TesiraHub = hass.data[DOMAIN][DICT_KEYS["DATA_HUBS"]][hubkey]
+    entities = copy.deepcopy(entry.options.get(DICT_KEYS["ENTITIES"], DEFAULTS["ENTITIES"]))
+    entities_list = []
+
+    # Build entities from the dynamic options structure by block type.
+    for entity in entities:
+        if "number" in entity[DICT_KEYS["ENTITY_BLOCK_SUPPORTED_TYPES"]]:
+            match entity[DICT_KEYS["ENTITY_BLOCK_TYPE"]]:
+                case "logic_delay":
+                    entities_list.append(TesiraLogicOnDelayBlock(hub=hub, hubkey=hubkey, entity=entity))
+                    entities_list.append(TesiraLogicOffDelayBlock(hub=hub, hubkey=hubkey, entity=entity))
+                case _:
+                    _LOGGER.debug(
+                        "Unsupported number block type '%s' for entity: %s",
+                        entity.get(DICT_KEYS["ENTITY_BLOCK_TYPE"]),
+                        entity,
+                    )
+
+
+    # Remove stale number entities no longer present in the current config.
+    entity_registry = er.async_get(hass)
+    expected_ids = {e.unique_id for e in entities_list}
+    for entity_entry in er.async_entries_for_config_entry(entity_registry, entry.entry_id):
+        if entity_entry.domain == "number" and entity_entry.unique_id not in expected_ids:
+            entity_registry.async_remove(entity_entry.entity_id)
+
+    async_add_entities(entities_list, update_before_add=True)
+
+class TesiraLogicOnDelayBlock(NumberEntity):
+    """Expose a Tesira logic on delay block as a Home Assistant number entity."""
+
+    def __init__(self, hub: TesiraHub, hubkey: str, entity: dict[str, Any]) -> None:
+        self._hub = hub
+        self._hubkey = hubkey
+        self._entity = entity
+        self._instance_tag = entity.get(DICT_KEYS["ENTITY_BLOCK_INSTANCE_TAG"])
+        self._block_type = entity.get(DICT_KEYS["ENTITY_BLOCK_TYPE"])
+        self._device_id = entity.get(DICT_KEYS["DEVICE_ID"])
+        self._channel = int(entity.get(DICT_KEYS["ENTITY_BLOCK_CHANNEL"]))
+        self._min_value = int(entity.get(DICT_KEYS["ENTITY_MIN_VALUE"]))
+        self._max_value = int(entity.get(DICT_KEYS["ENTITY_MAX_VALUE"]))
+        self._attr_name = f"Tesira Logic Delay Block - Tag:{self._instance_tag} - Attr:OnDelay - Chan:{self._channel} ({self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]})"
+        self._attr_unique_id = f"tesira_ttp_{self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]}_{self._block_type}_{self._instance_tag}_ondelay_{self._channel}".lower()
+        self._attr_mode = "box"
+        self._attr_native_step = 1
+        self._attr_native_max_value = self._max_value
+        self._attr_native_min_value = self._min_value
+        self._attr_device_class = NumberDeviceClass.DURATION
+        self._attr_native_unit_of_measurement = "ms"
+        self._attr_available = True
+
+    @property
+    def device_info(self):
+        return {DICT_KEYS["ENTITY_DEVICE_IDENTIFIERS"]: {(DOMAIN, self._device_id)}} if self._device_id != "None" else None
+
+    async def async_update(self) -> None:
+        try:
+            # Limits may differ between blocks/channels, so refresh before conversion each cycle.
+            resp = await self._hub.json(f"{self._instance_tag} get onDelayMs {self._channel}")
+            delay = resp["value"]
+            if delay is not None:
+                self._attr_native_value = delay
+                self._attr_available = True
+            else:
+                raise ValueError(f"Could not parse state from response: {resp!r}")
+        except Exception as e:
+            _LOGGER.debug("Update failed for %s: %s", self._attr_unique_id, e)
+            self._attr_available = False
+
+    async def async_set_native_value(self, value: int) -> None:
+        try:
+            await self._hub.json(f"{self._instance_tag} set onDelayMs {self._channel} {value}")
+            self._attr_is_on = True
+            self.async_write_ha_state()
+        except Exception as e:
+            _LOGGER.debug("Failed to set native value for %s: %s", self._attr_unique_id, e)
+
+class TesiraLogicOffDelayBlock(NumberEntity):
+    """Expose a Tesira logic off delay block as a Home Assistant number entity."""
+
+    def __init__(self, hub: TesiraHub, hubkey: str, entity: dict[str, Any]) -> None:
+        self._hub = hub
+        self._hubkey = hubkey
+        self._entity = entity
+        self._instance_tag = entity.get(DICT_KEYS["ENTITY_BLOCK_INSTANCE_TAG"])
+        self._block_type = entity.get(DICT_KEYS["ENTITY_BLOCK_TYPE"])
+        self._device_id = entity.get(DICT_KEYS["DEVICE_ID"])
+        self._channel = int(entity.get(DICT_KEYS["ENTITY_BLOCK_CHANNEL"]))
+        self._min_value = int(entity.get(DICT_KEYS["ENTITY_MIN_VALUE"]))
+        self._max_value = int(entity.get(DICT_KEYS["ENTITY_MAX_VALUE"]))
+        self._attr_name = f"Tesira Logic Delay Block - Tag:{self._instance_tag} - Attr:OffDelay - Chan:{self._channel} ({self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]})"
+        self._attr_unique_id = f"tesira_ttp_{self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]}_{self._block_type}_{self._instance_tag}_offdelay_{self._channel}".lower()
+        self._attr_mode = "box"
+        self._attr_native_step = 1
+        self._attr_native_max_value = self._max_value
+        self._attr_native_min_value = self._min_value
+        self._attr_device_class = NumberDeviceClass.DURATION
+        self._attr_native_unit_of_measurement = "ms"
+        self._attr_available = True
+
+    @property
+    def device_info(self):
+        return {DICT_KEYS["ENTITY_DEVICE_IDENTIFIERS"]: {(DOMAIN, self._device_id)}} if self._device_id != "None" else None
+
+    async def async_update(self) -> None:
+        try:
+            # Limits may differ between blocks/channels, so refresh before conversion each cycle.
+            resp = await self._hub.json(f"{self._instance_tag} get offDelayMs {self._channel}")
+            delay = resp["value"]
+            if delay is not None:
+                self._attr_native_value = delay
+                self._attr_available = True
+            else:
+                raise ValueError(f"Could not parse state from response: {resp!r}")
+        except Exception as e:
+            _LOGGER.debug("Update failed for %s: %s", self._attr_unique_id, e)
+            self._attr_available = False
+
+    async def async_set_native_value(self, value: int) -> None:
+        try:
+            await self._hub.json(f"{self._instance_tag} set offDelayMs {self._channel} {value}")
+            self._attr_is_on = True
+            self.async_write_ha_state()
+        except Exception as e:
+            _LOGGER.debug("Failed to set native value for %s: %s", self._attr_unique_id, e)

--- a/custom_components/tesira_ttp/number.py
+++ b/custom_components/tesira_ttp/number.py
@@ -2,7 +2,7 @@
 # Filename: \custom_components\tesira_ttp\number.py                                                                    #
 # Repository: tesira_ttp                                                                                               #
 # Created Date: Friday, May 8th 2026, 10:59:43 PM                                                                      #
-# Last Modified: Friday, May 8th 2026, 11:29:56 PM                                                                     #
+# Last Modified: Tuesday, July 7th 2026, 11:26:25 PM                                                                   #
 # Original Author: Darnel Kumar                                                                                        #
 # Author Github: https://github.com/Darnel-K                                                                           #
 #                                                                                                                      #
@@ -50,8 +50,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
         if "number" in entity[DICT_KEYS["ENTITY_BLOCK_SUPPORTED_TYPES"]]:
             match entity[DICT_KEYS["ENTITY_BLOCK_TYPE"]]:
                 case "logic_delay":
-                    entities_list.append(TesiraLogicOnDelayBlock(hub=hub, hubkey=hubkey, entity=entity))
-                    entities_list.append(TesiraLogicOffDelayBlock(hub=hub, hubkey=hubkey, entity=entity))
+                    entities_list.append(TesiraLogicDelayBlockOn(hub=hub, hubkey=hubkey, entity=entity))
+                    entities_list.append(TesiraLogicDelayBlockOff(hub=hub, hubkey=hubkey, entity=entity))
                 case _:
                     _LOGGER.debug(
                         "Unsupported number block type '%s' for entity: %s",
@@ -69,8 +69,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
 
     async_add_entities(entities_list, update_before_add=True)
 
-class TesiraLogicOnDelayBlock(NumberEntity):
-    """Expose a Tesira logic on delay block as a Home Assistant number entity."""
+class TesiraLogicDelayBlockOn(NumberEntity):
+    """Expose a Tesira logic delay block (On) as a Home Assistant number entity."""
 
     def __init__(self, hub: TesiraHub, hubkey: str, entity: dict[str, Any]) -> None:
         self._hub = hub
@@ -118,8 +118,8 @@ class TesiraLogicOnDelayBlock(NumberEntity):
         except Exception as e:
             _LOGGER.debug("Failed to set native value for %s: %s", self._attr_unique_id, e)
 
-class TesiraLogicOffDelayBlock(NumberEntity):
-    """Expose a Tesira logic off delay block as a Home Assistant number entity."""
+class TesiraLogicDelayBlockOff(NumberEntity):
+    """Expose a Tesira logic delay block (Off) as a Home Assistant number entity."""
 
     def __init__(self, hub: TesiraHub, hubkey: str, entity: dict[str, Any]) -> None:
         self._hub = hub
@@ -162,6 +162,104 @@ class TesiraLogicOffDelayBlock(NumberEntity):
     async def async_set_native_value(self, value: int) -> None:
         try:
             await self._hub.json(f"{self._instance_tag} set offDelayMs {self._channel} {value}")
+            self._attr_is_on = True
+            self.async_write_ha_state()
+        except Exception as e:
+            _LOGGER.debug("Failed to set native value for %s: %s", self._attr_unique_id, e)
+
+class TesiraLogicPulseBlockOffDuration(NumberEntity):
+    """Expose a Tesira logic pulse block (Off Duration) as a Home Assistant number entity."""
+
+    def __init__(self, hub: TesiraHub, hubkey: str, entity: dict[str, Any]) -> None:
+        self._hub = hub
+        self._hubkey = hubkey
+        self._entity = entity
+        self._instance_tag = entity.get(DICT_KEYS["ENTITY_BLOCK_INSTANCE_TAG"])
+        self._block_type = entity.get(DICT_KEYS["ENTITY_BLOCK_TYPE"])
+        self._device_id = entity.get(DICT_KEYS["DEVICE_ID"])
+        self._channel = int(entity.get(DICT_KEYS["ENTITY_BLOCK_CHANNEL"]))
+        self._min_value = int(entity.get(DICT_KEYS["ENTITY_MIN_VALUE"]))
+        self._max_value = int(entity.get(DICT_KEYS["ENTITY_MAX_VALUE"]))
+        self._attr_name = f"Tesira Logic Pulse Block - Tag:{self._instance_tag} - Attr:OffDuration - Chan:{self._channel} ({self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]})"
+        self._attr_unique_id = f"tesira_ttp_{self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]}_{self._block_type}_{self._instance_tag}_offduration_{self._channel}".lower()
+        self._attr_mode = "box"
+        self._attr_native_step = 1
+        self._attr_native_max_value = self._max_value
+        self._attr_native_min_value = self._min_value
+        self._attr_device_class = NumberDeviceClass.DURATION
+        self._attr_native_unit_of_measurement = "ms"
+        self._attr_available = True
+
+    @property
+    def device_info(self):
+        return {DICT_KEYS["ENTITY_DEVICE_IDENTIFIERS"]: {(DOMAIN, self._device_id)}} if self._device_id != "None" else None
+
+    async def async_update(self) -> None:
+        try:
+            # Limits may differ between blocks/channels, so refresh before conversion each cycle.
+            resp = await self._hub.json(f"{self._instance_tag} get durationOff {self._channel}")
+            off_duration = resp["value"]
+            if off_duration is not None:
+                self._attr_native_value = off_duration
+                self._attr_available = True
+            else:
+                raise ValueError(f"Could not parse state from response: {resp!r}")
+        except Exception as e:
+            _LOGGER.debug("Update failed for %s: %s", self._attr_unique_id, e)
+            self._attr_available = False
+
+    async def async_set_native_value(self, value: int) -> None:
+        try:
+            await self._hub.json(f"{self._instance_tag} set durationOff {self._channel} {value}")
+            self._attr_is_on = True
+            self.async_write_ha_state()
+        except Exception as e:
+            _LOGGER.debug("Failed to set native value for %s: %s", self._attr_unique_id, e)
+
+class TesiraLogicPulseBlockOnDuration(NumberEntity):
+    """Expose a Tesira logic pulse block (On Duration) as a Home Assistant number entity."""
+
+    def __init__(self, hub: TesiraHub, hubkey: str, entity: dict[str, Any]) -> None:
+        self._hub = hub
+        self._hubkey = hubkey
+        self._entity = entity
+        self._instance_tag = entity.get(DICT_KEYS["ENTITY_BLOCK_INSTANCE_TAG"])
+        self._block_type = entity.get(DICT_KEYS["ENTITY_BLOCK_TYPE"])
+        self._device_id = entity.get(DICT_KEYS["DEVICE_ID"])
+        self._channel = int(entity.get(DICT_KEYS["ENTITY_BLOCK_CHANNEL"]))
+        self._min_value = int(entity.get(DICT_KEYS["ENTITY_MIN_VALUE"]))
+        self._max_value = int(entity.get(DICT_KEYS["ENTITY_MAX_VALUE"]))
+        self._attr_name = f"Tesira Logic Pulse Block - Tag:{self._instance_tag} - Attr:OnDuration - Chan:{self._channel} ({self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]})"
+        self._attr_unique_id = f"tesira_ttp_{self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]}_{self._block_type}_{self._instance_tag}_onduration_{self._channel}".lower()
+        self._attr_mode = "box"
+        self._attr_native_step = 1
+        self._attr_native_max_value = self._max_value
+        self._attr_native_min_value = self._min_value
+        self._attr_device_class = NumberDeviceClass.DURATION
+        self._attr_native_unit_of_measurement = "ms"
+        self._attr_available = True
+
+    @property
+    def device_info(self):
+        return {DICT_KEYS["ENTITY_DEVICE_IDENTIFIERS"]: {(DOMAIN, self._device_id)}} if self._device_id != "None" else None
+
+    async def async_update(self) -> None:
+        try:
+            # Limits may differ between blocks/channels, so refresh before conversion each cycle.
+            resp = await self._hub.json(f"{self._instance_tag} get durationOn {self._channel}")
+            on_duration = resp["value"]
+            if on_duration is not None:
+                self._attr_native_value = on_duration
+                self._attr_available = True
+            else:
+                raise ValueError(f"Could not parse state from response: {resp!r}")
+        except Exception as e:
+            _LOGGER.debug("Update failed for %s: %s", self._attr_unique_id, e)
+            self._attr_available = False
+
+    async def async_set_native_value(self, value: int) -> None:
+        try:
+            await self._hub.json(f"{self._instance_tag} set durationOn {self._channel} {value}")
             self._attr_is_on = True
             self.async_write_ha_state()
         except Exception as e:

--- a/custom_components/tesira_ttp/number.py
+++ b/custom_components/tesira_ttp/number.py
@@ -1,8 +1,8 @@
 # #################################################################################################################### #
 # Filename: \custom_components\tesira_ttp\number.py                                                                    #
 # Repository: tesira_ttp                                                                                               #
-# Created Date: Tuesday, July 7th 2026, 11:50:58 PM                                                                    #
-# Last Modified: Tuesday, July 7th 2026, 11:55:24 PM                                                                   #
+# Created Date: Friday, May 8th 2026, 10:59:43 PM                                                                      #
+# Last Modified: Wednesday, July 8th 2026, 12:13:29 AM                                                                 #
 # Original Author: Darnel Kumar                                                                                        #
 # Author Github: https://github.com/Darnel-K                                                                           #
 #                                                                                                                      #
@@ -55,7 +55,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
                 case "logic_pulse":
                     entities_list.append(TesiraLogicPulseBlockOnDuration(hub=hub, hubkey=hubkey, entity=entity))
                     entities_list.append(TesiraLogicPulseBlockOffDuration(hub=hub, hubkey=hubkey, entity=entity))
-                    entities_list.append(TesiraLogicPulseBlockCount(hub=hub, hubkey=hubkey, entity=entity))
+                    entities_list.append(TesiraLogicPulseBlockPulseCount(hub=hub, hubkey=hubkey, entity=entity))
+                case "logic_sequence":
+                    entities_list.append(TesiraLogicSequenceBlockOnDuration(hub=hub, hubkey=hubkey, entity=entity))
+                    entities_list.append(TesiraLogicSequenceBlockOffDuration(hub=hub, hubkey=hubkey, entity=entity))
+                    entities_list.append(TesiraLogicSequenceBlockPulseCount(hub=hub, hubkey=hubkey, entity=entity))
                 case _:
                     _LOGGER.debug(
                         "Unsupported number block type '%s' for entity: %s",
@@ -269,7 +273,7 @@ class TesiraLogicPulseBlockOnDuration(NumberEntity):
         except Exception as e:
             _LOGGER.debug("Failed to set native value for %s: %s", self._attr_unique_id, e)
 
-class TesiraLogicPulseBlockCount(NumberEntity):
+class TesiraLogicPulseBlockPulseCount(NumberEntity):
     """Expose a Tesira logic pulse block (Pulse Count) as a Home Assistant number entity."""
 
     def __init__(self, hub: TesiraHub, hubkey: str, entity: dict[str, Any]) -> None:
@@ -298,9 +302,154 @@ class TesiraLogicPulseBlockCount(NumberEntity):
         try:
             # Limits may differ between blocks/channels, so refresh before conversion each cycle.
             resp = await self._hub.json(f"{self._instance_tag} get pulseCount {self._channel}")
+            pulse_count = resp["value"]
+            if pulse_count is not None:
+                self._attr_native_value = pulse_count
+                self._attr_available = True
+            else:
+                raise ValueError(f"Could not parse state from response: {resp!r}")
+        except Exception as e:
+            _LOGGER.debug("Update failed for %s: %s", self._attr_unique_id, e)
+            self._attr_available = False
+
+    async def async_set_native_value(self, value: int) -> None:
+        try:
+            await self._hub.json(f"{self._instance_tag} set pulseCount {self._channel} {value}")
+            self._attr_is_on = True
+            self.async_write_ha_state()
+        except Exception as e:
+            _LOGGER.debug("Failed to set native value for %s: %s", self._attr_unique_id, e)
+
+class TesiraLogicSequenceBlockOffDuration(NumberEntity):
+    """Expose a Tesira logic sequence block (Off Duration) as a Home Assistant number entity."""
+
+    def __init__(self, hub: TesiraHub, hubkey: str, entity: dict[str, Any]) -> None:
+        self._hub = hub
+        self._hubkey = hubkey
+        self._entity = entity
+        self._instance_tag = entity.get(DICT_KEYS["ENTITY_BLOCK_INSTANCE_TAG"])
+        self._block_type = entity.get(DICT_KEYS["ENTITY_BLOCK_TYPE"])
+        self._device_id = entity.get(DICT_KEYS["DEVICE_ID"])
+        self._channel = int(entity.get(DICT_KEYS["ENTITY_BLOCK_CHANNEL"]))
+        self._min_value = int(entity.get(DICT_KEYS["ENTITY_MIN_VALUE"])) if int(entity.get(DICT_KEYS["ENTITY_MIN_VALUE"])) >= 500 else 500
+        self._max_value = int(entity.get(DICT_KEYS["ENTITY_MAX_VALUE"])) if int(entity.get(DICT_KEYS["ENTITY_MAX_VALUE"])) <= 60000 else 60000
+        self._attr_name = f"Tesira Logic Sequence Block - Tag:{self._instance_tag} - Attr:OffDuration - Chan:{self._channel} ({self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]})"
+        self._attr_unique_id = f"tesira_ttp_{self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]}_{self._block_type}_{self._instance_tag}_offduration_{self._channel}".lower()
+        self._attr_mode = "box"
+        self._attr_native_step = 1
+        self._attr_native_max_value = self._max_value
+        self._attr_native_min_value = self._min_value
+        self._attr_device_class = NumberDeviceClass.DURATION
+        self._attr_native_unit_of_measurement = "ms"
+        self._attr_available = True
+
+    @property
+    def device_info(self):
+        return {DICT_KEYS["ENTITY_DEVICE_IDENTIFIERS"]: {(DOMAIN, self._device_id)}} if self._device_id != "None" else None
+
+    async def async_update(self) -> None:
+        try:
+            # Limits may differ between blocks/channels, so refresh before conversion each cycle.
+            resp = await self._hub.json(f"{self._instance_tag} get durationOff {self._channel}")
+            off_duration = resp["value"]
+            if off_duration is not None:
+                self._attr_native_value = off_duration
+                self._attr_available = True
+            else:
+                raise ValueError(f"Could not parse state from response: {resp!r}")
+        except Exception as e:
+            _LOGGER.debug("Update failed for %s: %s", self._attr_unique_id, e)
+            self._attr_available = False
+
+    async def async_set_native_value(self, value: int) -> None:
+        try:
+            await self._hub.json(f"{self._instance_tag} set durationOff {self._channel} {value}")
+            self._attr_is_on = True
+            self.async_write_ha_state()
+        except Exception as e:
+            _LOGGER.debug("Failed to set native value for %s: %s", self._attr_unique_id, e)
+
+class TesiraLogicSequenceBlockOnDuration(NumberEntity):
+    """Expose a Tesira logic sequence block (On Duration) as a Home Assistant number entity."""
+
+    def __init__(self, hub: TesiraHub, hubkey: str, entity: dict[str, Any]) -> None:
+        self._hub = hub
+        self._hubkey = hubkey
+        self._entity = entity
+        self._instance_tag = entity.get(DICT_KEYS["ENTITY_BLOCK_INSTANCE_TAG"])
+        self._block_type = entity.get(DICT_KEYS["ENTITY_BLOCK_TYPE"])
+        self._device_id = entity.get(DICT_KEYS["DEVICE_ID"])
+        self._channel = int(entity.get(DICT_KEYS["ENTITY_BLOCK_CHANNEL"]))
+        self._min_value = int(entity.get(DICT_KEYS["ENTITY_MIN_VALUE"])) if int(entity.get(DICT_KEYS["ENTITY_MIN_VALUE"])) >= 500 else 500
+        self._max_value = int(entity.get(DICT_KEYS["ENTITY_MAX_VALUE"])) if int(entity.get(DICT_KEYS["ENTITY_MAX_VALUE"])) <= 60000 else 60000
+        self._attr_name = f"Tesira Logic Sequence Block - Tag:{self._instance_tag} - Attr:OnDuration - Chan:{self._channel} ({self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]})"
+        self._attr_unique_id = f"tesira_ttp_{self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]}_{self._block_type}_{self._instance_tag}_onduration_{self._channel}".lower()
+        self._attr_mode = "box"
+        self._attr_native_step = 1
+        self._attr_native_max_value = self._max_value
+        self._attr_native_min_value = self._min_value
+        self._attr_device_class = NumberDeviceClass.DURATION
+        self._attr_native_unit_of_measurement = "ms"
+        self._attr_available = True
+
+    @property
+    def device_info(self):
+        return {DICT_KEYS["ENTITY_DEVICE_IDENTIFIERS"]: {(DOMAIN, self._device_id)}} if self._device_id != "None" else None
+
+    async def async_update(self) -> None:
+        try:
+            # Limits may differ between blocks/channels, so refresh before conversion each cycle.
+            resp = await self._hub.json(f"{self._instance_tag} get durationOn {self._channel}")
             on_duration = resp["value"]
             if on_duration is not None:
                 self._attr_native_value = on_duration
+                self._attr_available = True
+            else:
+                raise ValueError(f"Could not parse state from response: {resp!r}")
+        except Exception as e:
+            _LOGGER.debug("Update failed for %s: %s", self._attr_unique_id, e)
+            self._attr_available = False
+
+    async def async_set_native_value(self, value: int) -> None:
+        try:
+            await self._hub.json(f"{self._instance_tag} set durationOn {self._channel} {value}")
+            self._attr_is_on = True
+            self.async_write_ha_state()
+        except Exception as e:
+            _LOGGER.debug("Failed to set native value for %s: %s", self._attr_unique_id, e)
+
+class TesiraLogicSequenceBlockPulseCount(NumberEntity):
+    """Expose a Tesira logic sequence block (Pulse Count) as a Home Assistant number entity."""
+
+    def __init__(self, hub: TesiraHub, hubkey: str, entity: dict[str, Any]) -> None:
+        self._hub = hub
+        self._hubkey = hubkey
+        self._entity = entity
+        self._instance_tag = entity.get(DICT_KEYS["ENTITY_BLOCK_INSTANCE_TAG"])
+        self._block_type = entity.get(DICT_KEYS["ENTITY_BLOCK_TYPE"])
+        self._device_id = entity.get(DICT_KEYS["DEVICE_ID"])
+        self._channel = int(entity.get(DICT_KEYS["ENTITY_BLOCK_CHANNEL"]))
+        self._min_value = int(entity.get(DICT_KEYS["ENTITY_MIN_VALUE"])) if int(entity.get(DICT_KEYS["ENTITY_MIN_VALUE"])) >= 1 else 1
+        self._max_value = int(entity.get(DICT_KEYS["ENTITY_MAX_VALUE"])) if int(entity.get(DICT_KEYS["ENTITY_MAX_VALUE"])) <= 100 else 100
+        self._attr_name = f"Tesira Logic Sequence Block - Tag:{self._instance_tag} - Attr:PulseCount - Chan:{self._channel} ({self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]})"
+        self._attr_unique_id = f"tesira_ttp_{self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]}_{self._block_type}_{self._instance_tag}_pulsecount_{self._channel}".lower()
+        self._attr_mode = "box"
+        self._attr_native_step = 1
+        self._attr_native_max_value = self._max_value
+        self._attr_native_min_value = self._min_value
+        self._attr_available = True
+
+    @property
+    def device_info(self):
+        return {DICT_KEYS["ENTITY_DEVICE_IDENTIFIERS"]: {(DOMAIN, self._device_id)}} if self._device_id != "None" else None
+
+    async def async_update(self) -> None:
+        try:
+            # Limits may differ between blocks/channels, so refresh before conversion each cycle.
+            resp = await self._hub.json(f"{self._instance_tag} get pulseCount {self._channel}")
+            pulse_count = resp["value"]
+            if pulse_count is not None:
+                self._attr_native_value = pulse_count
                 self._attr_available = True
             else:
                 raise ValueError(f"Could not parse state from response: {resp!r}")

--- a/custom_components/tesira_ttp/number.py
+++ b/custom_components/tesira_ttp/number.py
@@ -1,8 +1,8 @@
 # #################################################################################################################### #
 # Filename: \custom_components\tesira_ttp\number.py                                                                    #
 # Repository: tesira_ttp                                                                                               #
-# Created Date: Friday, May 8th 2026, 10:59:43 PM                                                                      #
-# Last Modified: Wednesday, July 8th 2026, 12:13:29 AM                                                                 #
+# Created Date: Tuesday, July 7th 2026, 11:50:58 PM                                                                    #
+# Last Modified: Wednesday, July 8th 2026, 12:36:42 AM                                                                 #
 # Original Author: Darnel Kumar                                                                                        #
 # Author Github: https://github.com/Darnel-K                                                                           #
 #                                                                                                                      #
@@ -40,6 +40,8 @@ from .hub import TesiraHub
 _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities) -> None:
+    """Set up Tesira number entities for a config entry."""
+
     hubkey = entry.entry_id
     hub: TesiraHub = hass.data[DOMAIN][DICT_KEYS["DATA_HUBS"]][hubkey]
     entities = copy.deepcopy(entry.options.get(DICT_KEYS["ENTITIES"], DEFAULTS["ENTITIES"]))

--- a/custom_components/tesira_ttp/number.py
+++ b/custom_components/tesira_ttp/number.py
@@ -1,8 +1,8 @@
 # #################################################################################################################### #
 # Filename: \custom_components\tesira_ttp\number.py                                                                    #
 # Repository: tesira_ttp                                                                                               #
-# Created Date: Friday, May 8th 2026, 10:59:43 PM                                                                      #
-# Last Modified: Tuesday, July 7th 2026, 11:26:25 PM                                                                   #
+# Created Date: Tuesday, July 7th 2026, 11:50:58 PM                                                                    #
+# Last Modified: Tuesday, July 7th 2026, 11:55:24 PM                                                                   #
 # Original Author: Darnel Kumar                                                                                        #
 # Author Github: https://github.com/Darnel-K                                                                           #
 #                                                                                                                      #
@@ -52,6 +52,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
                 case "logic_delay":
                     entities_list.append(TesiraLogicDelayBlockOn(hub=hub, hubkey=hubkey, entity=entity))
                     entities_list.append(TesiraLogicDelayBlockOff(hub=hub, hubkey=hubkey, entity=entity))
+                case "logic_pulse":
+                    entities_list.append(TesiraLogicPulseBlockOnDuration(hub=hub, hubkey=hubkey, entity=entity))
+                    entities_list.append(TesiraLogicPulseBlockOffDuration(hub=hub, hubkey=hubkey, entity=entity))
+                    entities_list.append(TesiraLogicPulseBlockCount(hub=hub, hubkey=hubkey, entity=entity))
                 case _:
                     _LOGGER.debug(
                         "Unsupported number block type '%s' for entity: %s",
@@ -178,8 +182,8 @@ class TesiraLogicPulseBlockOffDuration(NumberEntity):
         self._block_type = entity.get(DICT_KEYS["ENTITY_BLOCK_TYPE"])
         self._device_id = entity.get(DICT_KEYS["DEVICE_ID"])
         self._channel = int(entity.get(DICT_KEYS["ENTITY_BLOCK_CHANNEL"]))
-        self._min_value = int(entity.get(DICT_KEYS["ENTITY_MIN_VALUE"]))
-        self._max_value = int(entity.get(DICT_KEYS["ENTITY_MAX_VALUE"]))
+        self._min_value = int(entity.get(DICT_KEYS["ENTITY_MIN_VALUE"])) if int(entity.get(DICT_KEYS["ENTITY_MIN_VALUE"])) >= 1000 else 1000
+        self._max_value = int(entity.get(DICT_KEYS["ENTITY_MAX_VALUE"])) if int(entity.get(DICT_KEYS["ENTITY_MAX_VALUE"])) <= 60000 else 60000
         self._attr_name = f"Tesira Logic Pulse Block - Tag:{self._instance_tag} - Attr:OffDuration - Chan:{self._channel} ({self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]})"
         self._attr_unique_id = f"tesira_ttp_{self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]}_{self._block_type}_{self._instance_tag}_offduration_{self._channel}".lower()
         self._attr_mode = "box"
@@ -227,8 +231,8 @@ class TesiraLogicPulseBlockOnDuration(NumberEntity):
         self._block_type = entity.get(DICT_KEYS["ENTITY_BLOCK_TYPE"])
         self._device_id = entity.get(DICT_KEYS["DEVICE_ID"])
         self._channel = int(entity.get(DICT_KEYS["ENTITY_BLOCK_CHANNEL"]))
-        self._min_value = int(entity.get(DICT_KEYS["ENTITY_MIN_VALUE"]))
-        self._max_value = int(entity.get(DICT_KEYS["ENTITY_MAX_VALUE"]))
+        self._min_value = int(entity.get(DICT_KEYS["ENTITY_MIN_VALUE"])) if int(entity.get(DICT_KEYS["ENTITY_MIN_VALUE"])) >= 1000 else 1000
+        self._max_value = int(entity.get(DICT_KEYS["ENTITY_MAX_VALUE"])) if int(entity.get(DICT_KEYS["ENTITY_MAX_VALUE"])) <= 60000 else 60000
         self._attr_name = f"Tesira Logic Pulse Block - Tag:{self._instance_tag} - Attr:OnDuration - Chan:{self._channel} ({self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]})"
         self._attr_unique_id = f"tesira_ttp_{self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]}_{self._block_type}_{self._instance_tag}_onduration_{self._channel}".lower()
         self._attr_mode = "box"
@@ -260,6 +264,53 @@ class TesiraLogicPulseBlockOnDuration(NumberEntity):
     async def async_set_native_value(self, value: int) -> None:
         try:
             await self._hub.json(f"{self._instance_tag} set durationOn {self._channel} {value}")
+            self._attr_is_on = True
+            self.async_write_ha_state()
+        except Exception as e:
+            _LOGGER.debug("Failed to set native value for %s: %s", self._attr_unique_id, e)
+
+class TesiraLogicPulseBlockCount(NumberEntity):
+    """Expose a Tesira logic pulse block (Pulse Count) as a Home Assistant number entity."""
+
+    def __init__(self, hub: TesiraHub, hubkey: str, entity: dict[str, Any]) -> None:
+        self._hub = hub
+        self._hubkey = hubkey
+        self._entity = entity
+        self._instance_tag = entity.get(DICT_KEYS["ENTITY_BLOCK_INSTANCE_TAG"])
+        self._block_type = entity.get(DICT_KEYS["ENTITY_BLOCK_TYPE"])
+        self._device_id = entity.get(DICT_KEYS["DEVICE_ID"])
+        self._channel = int(entity.get(DICT_KEYS["ENTITY_BLOCK_CHANNEL"]))
+        self._min_value = int(entity.get(DICT_KEYS["ENTITY_MIN_VALUE"])) if int(entity.get(DICT_KEYS["ENTITY_MIN_VALUE"])) >= 1 else 1
+        self._max_value = int(entity.get(DICT_KEYS["ENTITY_MAX_VALUE"])) if int(entity.get(DICT_KEYS["ENTITY_MAX_VALUE"])) <= 100 else 100
+        self._attr_name = f"Tesira Logic Pulse Block - Tag:{self._instance_tag} - Attr:PulseCount - Chan:{self._channel} ({self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]})"
+        self._attr_unique_id = f"tesira_ttp_{self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]}_{self._block_type}_{self._instance_tag}_pulsecount_{self._channel}".lower()
+        self._attr_mode = "box"
+        self._attr_native_step = 1
+        self._attr_native_max_value = self._max_value
+        self._attr_native_min_value = self._min_value
+        self._attr_available = True
+
+    @property
+    def device_info(self):
+        return {DICT_KEYS["ENTITY_DEVICE_IDENTIFIERS"]: {(DOMAIN, self._device_id)}} if self._device_id != "None" else None
+
+    async def async_update(self) -> None:
+        try:
+            # Limits may differ between blocks/channels, so refresh before conversion each cycle.
+            resp = await self._hub.json(f"{self._instance_tag} get pulseCount {self._channel}")
+            on_duration = resp["value"]
+            if on_duration is not None:
+                self._attr_native_value = on_duration
+                self._attr_available = True
+            else:
+                raise ValueError(f"Could not parse state from response: {resp!r}")
+        except Exception as e:
+            _LOGGER.debug("Update failed for %s: %s", self._attr_unique_id, e)
+            self._attr_available = False
+
+    async def async_set_native_value(self, value: int) -> None:
+        try:
+            await self._hub.json(f"{self._instance_tag} set pulseCount {self._channel} {value}")
             self._attr_is_on = True
             self.async_write_ha_state()
         except Exception as e:

--- a/custom_components/tesira_ttp/schemas.py
+++ b/custom_components/tesira_ttp/schemas.py
@@ -1,8 +1,8 @@
 # #################################################################################################################### #
 # Filename: \custom_components\tesira_ttp\schemas.py                                                                   #
 # Repository: tesira_ttp                                                                                               #
-# Created Date: Saturday, March 28th 2026, 10:45:20 PM                                                                 #
-# Last Modified: Thursday, April 16th 2026, 11:33:40 PM                                                                #
+# Created Date: Monday, April 13th 2026, 12:33:01 AM                                                                   #
+# Last Modified: Saturday, May 9th 2026, 12:14:05 AM                                                                   #
 # Original Author: Darnel Kumar                                                                                        #
 # Author Github: https://github.com/Darnel-K                                                                           #
 #                                                                                                                      #
@@ -68,7 +68,8 @@ def _entity_schema(defaults: dict[str, Any] | None = None, block_type: str | Non
         raise ValueError(f"Unsupported block type: {block_type}")
 
     block_data = BLOCK_SCHEMA_DATA[block_type]
-    fields = block_data.get("fields", [])
+    fields = block_data.get(DICT_KEYS["ENTITY_BLOCK_FIELDS"], [])
+    field_options = block_data.get(DICT_KEYS["ENTITY_BLOCK_FIELD_OPTIONS"], None)
     schema_dict = {}
 
     # Convert declarative field metadata into voluptuous validators at runtime.
@@ -77,13 +78,31 @@ def _entity_schema(defaults: dict[str, Any] | None = None, block_type: str | Non
         default_value = d.get(field, field_info.get("default", None))
         required = field_info.get("required", False)
         field_type = field_info.get("type", "string")
+        options = None
+
+        if field_options and field in field_options:
+            options = field_options.get(field, None)
+            if options.get(DICT_KEYS["ENTITY_FIELD_TYPE_OVERRIDE"], None) is not None:
+                field_type = options[DICT_KEYS["ENTITY_FIELD_TYPE_OVERRIDE"]]
 
         if field_type == "string":
             validator = cv.string
         elif field_type == "integer":
-            validator = vol.Coerce(int)
+            if isinstance(options, dict):
+                if ("min" in options and isinstance(options["min"], int)) and ("max" in options and isinstance(options["max"], int)):
+                    validator = vol.All(vol.Coerce(int), vol.Range(min=options["min"], max=options["max"]))
+                else:
+                    raise ValueError(f"Invalid options for integer field '{field}', cannot mix int and float: {options}")
+            else:
+                validator = vol.Coerce(int)
         elif field_type == "float":
-            validator = vol.Coerce(float)
+            if isinstance(options, dict):
+                if ("min" in options and isinstance(options["min"], (int, float))) and ("max" in options and isinstance(options["max"], (int, float))):
+                    validator = vol.All(vol.Coerce(float), vol.Range(min=options["min"], max=options["max"]))
+                else:
+                    raise ValueError(f"Invalid options for float field '{field}': {options}")
+            else:
+                validator = vol.Coerce(float)
         elif field_type == "boolean":
             validator = vol.Coerce(bool)
         elif field_type == "port":

--- a/custom_components/tesira_ttp/switch.py
+++ b/custom_components/tesira_ttp/switch.py
@@ -2,7 +2,7 @@
 # Filename: \custom_components\tesira_ttp\switch.py                                                                    #
 # Repository: tesira_ttp                                                                                               #
 # Created Date: Friday, May 8th 2026, 10:59:43 PM                                                                      #
-# Last Modified: Tuesday, July 7th 2026, 11:26:25 PM                                                                   #
+# Last Modified: Wednesday, July 8th 2026, 12:09:45 AM                                                                 #
 # Original Author: Darnel Kumar                                                                                        #
 # Author Github: https://github.com/Darnel-K                                                                           #
 #                                                                                                                      #
@@ -64,7 +64,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
                 case "logic_output":
                     entities_list.append(TesiraLogicOutputBlock(hub=hub, hubkey=hubkey, entity=entity))
                 case "logic_pulse":
-                    entities_list.append(TesiraLogicPulseBlock(hub=hub, hubkey=hubkey, entity=entity))
+                    entities_list.append(TesiraLogicPulseBlockIndefinite(hub=hub, hubkey=hubkey, entity=entity))
+                case "logic_sequence":
+                    entities_list.append(TesiraLogicSequenceBlockIndefinite(hub=hub, hubkey=hubkey, entity=entity))
                 case _:
                     _LOGGER.debug(
                         "Unsupported switch block type '%s' for entity: %s",
@@ -505,8 +507,8 @@ class TesiraLogicSelectorBlock(SwitchEntity):
         except Exception as e:
             _LOGGER.debug("Toggle failed for %s: %s", self._attr_unique_id, e)
 
-class TesiraLogicPulseBlock(SwitchEntity):
-    """Expose a Tesira logic pulse block as a Home Assistant switch entity."""
+class TesiraLogicPulseBlockIndefinite(SwitchEntity):
+    """Expose a Tesira logic pulse block (Indefinite) as a Home Assistant switch entity."""
 
     def __init__(self, hub: TesiraHub, hubkey: str, entity: dict[str, Any]) -> None:
         self._hub = hub
@@ -517,6 +519,63 @@ class TesiraLogicPulseBlock(SwitchEntity):
         self._device_id = entity.get(DICT_KEYS["DEVICE_ID"])
         self._channel = int(entity.get(DICT_KEYS["ENTITY_BLOCK_CHANNEL"]))
         self._attr_name = f"Tesira Logic Pulse Block - Tag:{self._instance_tag} - Attr:Indefinite - Chan:{self._channel} ({self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]})"
+        self._attr_unique_id = f"tesira_ttp_{self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]}_{self._block_type}_{self._instance_tag}_indefinite_{self._channel}".lower()
+        self._attr_is_on: bool = False
+        self._attr_available = True
+
+    @property
+    def device_info(self):
+        return {DICT_KEYS["ENTITY_DEVICE_IDENTIFIERS"]: {(DOMAIN, self._device_id)}} if self._device_id != "None" else None
+
+    async def async_update(self) -> None:
+        try:
+            # Limits may differ between blocks/channels, so refresh before conversion each cycle.
+            resp = await self._hub.json(f"{self._instance_tag} get indefinite {self._channel}")
+            indefinite = resp["value"]
+            if indefinite is not None:
+                self._attr_is_on = _coerce_bool(indefinite)
+                self._attr_available = True
+            else:
+                raise ValueError(f"Could not parse indefinite state from response: {resp!r}")
+        except Exception as e:
+            _LOGGER.debug("Update failed for %s: %s", self._attr_unique_id, e)
+            self._attr_available = False
+
+    async def async_turn_on(self) -> None:
+        try:
+            await self._hub.json(f"{self._instance_tag} set indefinite {self._channel} true")
+            self._attr_is_on = True
+            self.async_write_ha_state()
+        except Exception as e:
+            _LOGGER.debug("Turn on failed for %s: %s", self._attr_unique_id, e)
+
+    async def async_turn_off(self) -> None:
+        try:
+            await self._hub.json(f"{self._instance_tag} set indefinite {self._channel} false")
+            self._attr_is_on = False
+            self.async_write_ha_state()
+        except Exception as e:
+            _LOGGER.debug("Turn off failed for %s: %s", self._attr_unique_id, e)
+
+    async def async_toggle(self) -> None:
+        try:
+            await self._hub.json(f"{self._instance_tag} toggle indefinite {self._channel}")
+            await self.async_update()  # Refresh state after toggle since we don't know the resulting state in advance.
+        except Exception as e:
+            _LOGGER.debug("Toggle failed for %s: %s", self._attr_unique_id, e)
+
+class TesiraLogicSequenceBlockIndefinite(SwitchEntity):
+    """Expose a Tesira logic sequence block (Indefinite) as a Home Assistant switch entity."""
+
+    def __init__(self, hub: TesiraHub, hubkey: str, entity: dict[str, Any]) -> None:
+        self._hub = hub
+        self._hubkey = hubkey
+        self._entity = entity
+        self._instance_tag = entity.get(DICT_KEYS["ENTITY_BLOCK_INSTANCE_TAG"])
+        self._block_type = entity.get(DICT_KEYS["ENTITY_BLOCK_TYPE"])
+        self._device_id = entity.get(DICT_KEYS["DEVICE_ID"])
+        self._channel = int(entity.get(DICT_KEYS["ENTITY_BLOCK_CHANNEL"]))
+        self._attr_name = f"Tesira Logic Sequence Block - Tag:{self._instance_tag} - Attr:Indefinite - Chan:{self._channel} ({self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]})"
         self._attr_unique_id = f"tesira_ttp_{self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]}_{self._block_type}_{self._instance_tag}_indefinite_{self._channel}".lower()
         self._attr_is_on: bool = False
         self._attr_available = True

--- a/custom_components/tesira_ttp/switch.py
+++ b/custom_components/tesira_ttp/switch.py
@@ -1,8 +1,8 @@
 # #################################################################################################################### #
 # Filename: \custom_components\tesira_ttp\switch.py                                                                    #
 # Repository: tesira_ttp                                                                                               #
-# Created Date: Friday, May 8th 2026, 10:59:43 PM                                                                      #
-# Last Modified: Friday, May 8th 2026, 11:12:30 PM                                                                     #
+# Created Date: Thursday, March 19th 2026, 12:56:52 AM                                                                 #
+# Last Modified: Tuesday, July 7th 2026, 11:02:05 PM                                                                   #
 # Original Author: Darnel Kumar                                                                                        #
 # Author Github: https://github.com/Darnel-K                                                                           #
 #                                                                                                                      #
@@ -53,10 +53,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
             match entity[DICT_KEYS["ENTITY_BLOCK_TYPE"]]:
                 case "logic_state":
                     entities_list.append(TesiraLogicStateBlock(hub=hub, hubkey=hubkey, entity=entity))
+                case "logic_selector":
+                    entities_list.append(TesiraLogicSelectorBlock(hub=hub, hubkey=hubkey, entity=entity))
                 case "flip_flop":
                     entities_list.append(TesiraFlipFlopBlock(hub=hub, hubkey=hubkey, entity=entity))
                 case "logic_delay":
                     entities_list.append(TesiraLogicDelayBlock(hub=hub, hubkey=hubkey, entity=entity))
+                case "logic_input":
+                    entities_list.append(TesiraLogicInputBlock(hub=hub, hubkey=hubkey, entity=entity))
+                case "logic_output":
+                    entities_list.append(TesiraLogicOutputBlock(hub=hub, hubkey=hubkey, entity=entity))
                 case _:
                     _LOGGER.debug(
                         "Unsupported switch block type '%s' for entity: %s",
@@ -295,6 +301,204 @@ class TesiraLogicDelayBlock(SwitchEntity):
     async def async_toggle(self) -> None:
         try:
             await self._hub.json(f"{self._instance_tag} toggle bypass {self._channel}")
+            await self.async_update()  # Refresh state after toggle since we don't know the resulting state in advance.
+        except Exception as e:
+            _LOGGER.debug("Toggle failed for %s: %s", self._attr_unique_id, e)
+
+class TesiraLogicInputBlock(SwitchEntity):
+    """Expose a Tesira logic input block as a Home Assistant switch entity."""
+
+    def __init__(self, hub: TesiraHub, hubkey: str, entity: dict[str, Any]) -> None:
+        self._hub = hub
+        self._hubkey = hubkey
+        self._entity = entity
+        self._instance_tag = entity.get(DICT_KEYS["ENTITY_BLOCK_INSTANCE_TAG"])
+        self._block_type = entity.get(DICT_KEYS["ENTITY_BLOCK_TYPE"])
+        self._device_id = entity.get(DICT_KEYS["DEVICE_ID"])
+        self._channel = int(entity.get(DICT_KEYS["ENTITY_BLOCK_CHANNEL"]))
+        self._attr_name = f"Tesira Logic Input Block - Tag:{self._instance_tag} - Attr:Invert - Chan:{self._channel} ({self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]})"
+        self._attr_unique_id = f"tesira_ttp_{self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]}_{self._block_type}_{self._instance_tag}_invert_{self._channel}".lower()
+        self._attr_is_on: bool = False
+        self._attr_available = True
+
+    @property
+    def device_info(self):
+        return {DICT_KEYS["ENTITY_DEVICE_IDENTIFIERS"]: {(DOMAIN, self._device_id)}} if self._device_id != "None" else None
+
+    async def async_update(self) -> None:
+        try:
+            # Limits may differ between blocks/channels, so refresh before conversion each cycle.
+            resp = await self._hub.json(f"{self._instance_tag} get invert {self._channel}")
+            state = resp["value"]
+            if state is not None:
+                self._attr_is_on = _coerce_bool(state)
+                self._attr_available = True
+            else:
+                raise ValueError(f"Could not parse invert state from response: {resp!r}")
+        except Exception as e:
+            _LOGGER.debug("Update failed for %s: %s", self._attr_unique_id, e)
+            self._attr_available = False
+
+    async def async_turn_on(self) -> None:
+        try:
+            await self._hub.json(f"{self._instance_tag} set invert {self._channel} true")
+            self._attr_is_on = True
+            self.async_write_ha_state()
+        except Exception as e:
+            _LOGGER.debug("Turn on failed for %s: %s", self._attr_unique_id, e)
+
+    async def async_turn_off(self) -> None:
+        try:
+            await self._hub.json(f"{self._instance_tag} set invert {self._channel} false")
+            self._attr_is_on = False
+            self.async_write_ha_state()
+        except Exception as e:
+            _LOGGER.debug("Turn off failed for %s: %s", self._attr_unique_id, e)
+
+    async def async_toggle(self) -> None:
+        try:
+            await self._hub.json(f"{self._instance_tag} toggle invert {self._channel}")
+            await self.async_update()  # Refresh state after toggle since we don't know the resulting state in advance.
+        except Exception as e:
+            _LOGGER.debug("Toggle failed for %s: %s", self._attr_unique_id, e)
+
+class TesiraLogicOutputBlock(SwitchEntity):
+    """Expose a Tesira logic output block as a Home Assistant switch entity."""
+
+    def __init__(self, hub: TesiraHub, hubkey: str, entity: dict[str, Any]) -> None:
+        self._hub = hub
+        self._hubkey = hubkey
+        self._entity = entity
+        self._instance_tag = entity.get(DICT_KEYS["ENTITY_BLOCK_INSTANCE_TAG"])
+        self._block_type = entity.get(DICT_KEYS["ENTITY_BLOCK_TYPE"])
+        self._device_id = entity.get(DICT_KEYS["DEVICE_ID"])
+        self._channel = int(entity.get(DICT_KEYS["ENTITY_BLOCK_CHANNEL"]))
+        self._attr_name = f"Tesira Logic Output Block - Tag:{self._instance_tag} - Attr:Invert - Chan:{self._channel} ({self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]})"
+        self._attr_unique_id = f"tesira_ttp_{self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]}_{self._block_type}_{self._instance_tag}_invert_{self._channel}".lower()
+        self._attr_is_on: bool = False
+        self._attr_available = True
+
+    @property
+    def device_info(self):
+        return {DICT_KEYS["ENTITY_DEVICE_IDENTIFIERS"]: {(DOMAIN, self._device_id)}} if self._device_id != "None" else None
+
+    async def async_update(self) -> None:
+        try:
+            # Limits may differ between blocks/channels, so refresh before conversion each cycle.
+            resp = await self._hub.json(f"{self._instance_tag} get invert {self._channel}")
+            state = resp["value"]
+            if state is not None:
+                self._attr_is_on = _coerce_bool(state)
+                self._attr_available = True
+            else:
+                raise ValueError(f"Could not parse invert state from response: {resp!r}")
+        except Exception as e:
+            _LOGGER.debug("Update failed for %s: %s", self._attr_unique_id, e)
+            self._attr_available = False
+
+    async def async_turn_on(self) -> None:
+        try:
+            await self._hub.json(f"{self._instance_tag} set invert {self._channel} true")
+            self._attr_is_on = True
+            self.async_write_ha_state()
+        except Exception as e:
+            _LOGGER.debug("Turn on failed for %s: %s", self._attr_unique_id, e)
+
+    async def async_turn_off(self) -> None:
+        try:
+            await self._hub.json(f"{self._instance_tag} set invert {self._channel} false")
+            self._attr_is_on = False
+            self.async_write_ha_state()
+        except Exception as e:
+            _LOGGER.debug("Turn off failed for %s: %s", self._attr_unique_id, e)
+
+    async def async_toggle(self) -> None:
+        try:
+            await self._hub.json(f"{self._instance_tag} toggle invert {self._channel}")
+            await self.async_update()  # Refresh state after toggle since we don't know the resulting state in advance.
+        except Exception as e:
+            _LOGGER.debug("Toggle failed for %s: %s", self._attr_unique_id, e)
+
+class TesiraLogicSelectorBlock(SwitchEntity):
+    """Expose a Tesira logic selector block as a Home Assistant switch entity."""
+
+    def __init__(self, hub: TesiraHub, hubkey: str, entity: dict[str, Any]) -> None:
+        self._hub = hub
+        self._hubkey = hubkey
+        self._entity = entity
+        self._instance_tag = entity.get(DICT_KEYS["ENTITY_BLOCK_INSTANCE_TAG"])
+        self._block_type = entity.get(DICT_KEYS["ENTITY_BLOCK_TYPE"])
+        self._device_id = entity.get(DICT_KEYS["DEVICE_ID"])
+        self._channel = int(entity.get(DICT_KEYS["ENTITY_BLOCK_CHANNEL"]))
+        self._sub = entity.get(DICT_KEYS["ENTITY_BLOCK_SUBSCRIBE"])
+        self._attr_name = f"Tesira Logic Selector Block - Tag:{self._instance_tag} - Attr:State - Chan:{self._channel} ({self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]})"
+        self._attr_unique_id = f"tesira_ttp_{self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]}_{self._block_type}_{self._instance_tag}_state_{self._channel}".lower()
+        self._attr_is_on: bool = False
+        self._attr_available = True
+
+        if self._sub:
+            # Subscription mode pushes updates from the DSP, so polling is unnecessary.
+            self._attr_should_poll = False
+        else:
+            self._attr_should_poll = True
+
+    @property
+    def device_info(self):
+        return {DICT_KEYS["ENTITY_DEVICE_IDENTIFIERS"]: {(DOMAIN, self._device_id)}} if self._device_id != "None" else None
+
+    def _update_state_from_sub(self, data: dict) -> None:
+        state = data.get("value")
+        if state is not None:
+            self._attr_is_on = _coerce_bool(state)
+            self._attr_available = True
+            self._hass.loop.call_soon_threadsafe(self.async_write_ha_state)
+        else:
+            _LOGGER.warning("Received subscription update without state value: %s", data)
+
+    async def async_added_to_hass(self) -> None:
+        self._hass = self.hass
+        if self._sub:
+            # Prime state once before starting subscriptions to avoid an empty initial UI state.
+            await self.async_update()
+            await self._hub.subscribe(self._instance_tag, "state", self._channel, f"hass_switch_logic_selector_{self._instance_tag}_{self._channel}", 100, self._update_state_from_sub)
+
+    async def async_will_remove_from_hass(self) -> None:
+        if self._sub:
+            await self._hub.unsubscribe(f"hass_switch_logic_selector_{self._instance_tag}_{self._channel}")
+
+    async def async_update(self) -> None:
+        try:
+            # Limits may differ between blocks/channels, so refresh before conversion each cycle.
+            resp = await self._hub.json(f"{self._instance_tag} get state {self._channel}")
+            state = resp["value"]
+            if state is not None:
+                self._attr_is_on = _coerce_bool(state)
+                self._attr_available = True
+            else:
+                raise ValueError(f"Could not parse state from response: {resp!r}")
+        except Exception as e:
+            _LOGGER.debug("Update failed for %s: %s", self._attr_unique_id, e)
+            self._attr_available = False
+
+    async def async_turn_on(self) -> None:
+        try:
+            await self._hub.json(f"{self._instance_tag} set state {self._channel} true")
+            self._attr_is_on = True
+            self.async_write_ha_state()
+        except Exception as e:
+            _LOGGER.debug("Turn on failed for %s: %s", self._attr_unique_id, e)
+
+    async def async_turn_off(self) -> None:
+        try:
+            await self._hub.json(f"{self._instance_tag} set state {self._channel} false")
+            self._attr_is_on = False
+            self.async_write_ha_state()
+        except Exception as e:
+            _LOGGER.debug("Turn off failed for %s: %s", self._attr_unique_id, e)
+
+    async def async_toggle(self) -> None:
+        try:
+            await self._hub.json(f"{self._instance_tag} toggle {self._channel}")
             await self.async_update()  # Refresh state after toggle since we don't know the resulting state in advance.
         except Exception as e:
             _LOGGER.debug("Toggle failed for %s: %s", self._attr_unique_id, e)

--- a/custom_components/tesira_ttp/switch.py
+++ b/custom_components/tesira_ttp/switch.py
@@ -2,7 +2,7 @@
 # Filename: \custom_components\tesira_ttp\switch.py                                                                    #
 # Repository: tesira_ttp                                                                                               #
 # Created Date: Thursday, April 16th 2026, 11:44:37 PM                                                                 #
-# Last Modified: Friday, April 17th 2026, 12:22:30 AM                                                                  #
+# Last Modified: Friday, May 8th 2026, 10:45:26 PM                                                                     #
 # Original Author: Darnel Kumar                                                                                        #
 # Author Github: https://github.com/Darnel-K                                                                           #
 #                                                                                                                      #
@@ -53,6 +53,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
             match entity[DICT_KEYS["ENTITY_BLOCK_TYPE"]]:
                 case "logic_state":
                     entities_list.append(TesiraLogicStateBlock(hub=hub, hubkey=hubkey, entity=entity))
+                case "flip_flop":
+                    entities_list.append(TesiraFlipFlopBlock(hub=hub, hubkey=hubkey, entity=entity))
+                case _:
+                    _LOGGER.debug(
+                        "Unsupported switch block type '%s' for entity: %s",
+                        entity.get(DICT_KEYS["ENTITY_BLOCK_TYPE"]),
+                        entity,
+                    )
 
 
     # Remove stale switch entities no longer present in the current config.
@@ -65,7 +73,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     async_add_entities(entities_list, update_before_add=True)
 
 class TesiraLogicStateBlock(SwitchEntity):
-    """Expose a Tesira logic block state as a Home Assistant switch entity."""
+    """Expose a Tesira logic state block as a Home Assistant switch entity."""
 
     def __init__(self, hub: TesiraHub, hubkey: str, entity: dict[str, Any]) -> None:
         self._hub = hub
@@ -110,6 +118,90 @@ class TesiraLogicStateBlock(SwitchEntity):
     async def async_will_remove_from_hass(self) -> None:
         if self._sub:
             await self._hub.unsubscribe(f"hass_switch_logic_state_{self._instance_tag}_{self._channel}")
+
+    async def async_update(self) -> None:
+        try:
+            # Limits may differ between blocks/channels, so refresh before conversion each cycle.
+            resp = await self._hub.json(f"{self._instance_tag} get state {self._channel}")
+            state = resp["value"]
+            if state is not None:
+                self._attr_is_on = _coerce_bool(state)
+                self._attr_available = True
+            else:
+                raise ValueError(f"Could not parse state from response: {resp!r}")
+        except Exception as e:
+            _LOGGER.debug("Update failed for %s: %s", self._attr_unique_id, e)
+            self._attr_available = False
+
+    async def async_turn_on(self) -> None:
+        try:
+            await self._hub.json(f"{self._instance_tag} set state {self._channel} true")
+            self._attr_is_on = True
+            self.async_write_ha_state()
+        except Exception as e:
+            _LOGGER.debug("Turn on failed for %s: %s", self._attr_unique_id, e)
+
+    async def async_turn_off(self) -> None:
+        try:
+            await self._hub.json(f"{self._instance_tag} set state {self._channel} false")
+            self._attr_is_on = False
+            self.async_write_ha_state()
+        except Exception as e:
+            _LOGGER.debug("Turn off failed for %s: %s", self._attr_unique_id, e)
+
+    async def async_toggle(self) -> None:
+        try:
+            await self._hub.json(f"{self._instance_tag} toggle {self._channel}")
+            await self.async_update()  # Refresh state after toggle since we don't know the resulting state in advance.
+        except Exception as e:
+            _LOGGER.debug("Toggle failed for %s: %s", self._attr_unique_id, e)
+
+class TesiraFlipFlopBlock(SwitchEntity):
+    """Expose a Tesira flip flop block as a Home Assistant switch entity."""
+
+    def __init__(self, hub: TesiraHub, hubkey: str, entity: dict[str, Any]) -> None:
+        self._hub = hub
+        self._hubkey = hubkey
+        self._entity = entity
+        self._instance_tag = entity.get(DICT_KEYS["ENTITY_BLOCK_INSTANCE_TAG"])
+        self._block_type = entity.get(DICT_KEYS["ENTITY_BLOCK_TYPE"])
+        self._device_id = entity.get(DICT_KEYS["DEVICE_ID"])
+        self._channel = int(entity.get(DICT_KEYS["ENTITY_BLOCK_CHANNEL"]))
+        self._sub = entity.get(DICT_KEYS["ENTITY_BLOCK_SUBSCRIBE"])
+        self._attr_name = f"Tesira Flip Flop Block - Tag:{self._instance_tag} - Attr:State - Chan:{self._channel} ({self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]})"
+        self._attr_unique_id = f"tesira_ttp_{self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]}_{self._block_type}_{self._instance_tag}_state_{self._channel}".lower()
+        self._attr_is_on: bool = False
+        self._attr_available = True
+
+        if self._sub:
+            # Subscription mode pushes updates from the DSP, so polling is unnecessary.
+            self._attr_should_poll = False
+        else:
+            self._attr_should_poll = True
+
+    @property
+    def device_info(self):
+        return {DICT_KEYS["ENTITY_DEVICE_IDENTIFIERS"]: {(DOMAIN, self._device_id)}} if self._device_id != "None" else None
+
+    def _update_state_from_sub(self, data: dict) -> None:
+        state = data.get("value")
+        if state is not None:
+            self._attr_is_on = _coerce_bool(state)
+            self._attr_available = True
+            self._hass.loop.call_soon_threadsafe(self.async_write_ha_state)
+        else:
+            _LOGGER.warning("Received subscription update without state value: %s", data)
+
+    async def async_added_to_hass(self) -> None:
+        self._hass = self.hass
+        if self._sub:
+            # Prime state once before starting subscriptions to avoid an empty initial UI state.
+            await self.async_update()
+            await self._hub.subscribe(self._instance_tag, "state", self._channel, f"hass_switch_flip_flop_{self._instance_tag}_{self._channel}", 100, self._update_state_from_sub)
+
+    async def async_will_remove_from_hass(self) -> None:
+        if self._sub:
+            await self._hub.unsubscribe(f"hass_switch_flip_flop_{self._instance_tag}_{self._channel}")
 
     async def async_update(self) -> None:
         try:

--- a/custom_components/tesira_ttp/switch.py
+++ b/custom_components/tesira_ttp/switch.py
@@ -1,8 +1,8 @@
 # #################################################################################################################### #
 # Filename: \custom_components\tesira_ttp\switch.py                                                                    #
 # Repository: tesira_ttp                                                                                               #
-# Created Date: Thursday, April 16th 2026, 11:44:37 PM                                                                 #
-# Last Modified: Friday, May 8th 2026, 10:45:26 PM                                                                     #
+# Created Date: Friday, May 8th 2026, 10:59:43 PM                                                                      #
+# Last Modified: Friday, May 8th 2026, 11:12:30 PM                                                                     #
 # Original Author: Darnel Kumar                                                                                        #
 # Author Github: https://github.com/Darnel-K                                                                           #
 #                                                                                                                      #
@@ -55,6 +55,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
                     entities_list.append(TesiraLogicStateBlock(hub=hub, hubkey=hubkey, entity=entity))
                 case "flip_flop":
                     entities_list.append(TesiraFlipFlopBlock(hub=hub, hubkey=hubkey, entity=entity))
+                case "logic_delay":
+                    entities_list.append(TesiraLogicDelayBlock(hub=hub, hubkey=hubkey, entity=entity))
                 case _:
                     _LOGGER.debug(
                         "Unsupported switch block type '%s' for entity: %s",
@@ -236,6 +238,63 @@ class TesiraFlipFlopBlock(SwitchEntity):
     async def async_toggle(self) -> None:
         try:
             await self._hub.json(f"{self._instance_tag} toggle {self._channel}")
+            await self.async_update()  # Refresh state after toggle since we don't know the resulting state in advance.
+        except Exception as e:
+            _LOGGER.debug("Toggle failed for %s: %s", self._attr_unique_id, e)
+
+class TesiraLogicDelayBlock(SwitchEntity):
+    """Expose a Tesira logic delay block as a Home Assistant switch entity."""
+
+    def __init__(self, hub: TesiraHub, hubkey: str, entity: dict[str, Any]) -> None:
+        self._hub = hub
+        self._hubkey = hubkey
+        self._entity = entity
+        self._instance_tag = entity.get(DICT_KEYS["ENTITY_BLOCK_INSTANCE_TAG"])
+        self._block_type = entity.get(DICT_KEYS["ENTITY_BLOCK_TYPE"])
+        self._device_id = entity.get(DICT_KEYS["DEVICE_ID"])
+        self._channel = int(entity.get(DICT_KEYS["ENTITY_BLOCK_CHANNEL"]))
+        self._attr_name = f"Tesira Logic Delay Block - Tag:{self._instance_tag} - Attr:Bypass - Chan:{self._channel} ({self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]})"
+        self._attr_unique_id = f"tesira_ttp_{self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]}_{self._block_type}_{self._instance_tag}_bypass_{self._channel}".lower()
+        self._attr_is_on: bool = False
+        self._attr_available = True
+
+    @property
+    def device_info(self):
+        return {DICT_KEYS["ENTITY_DEVICE_IDENTIFIERS"]: {(DOMAIN, self._device_id)}} if self._device_id != "None" else None
+
+    async def async_update(self) -> None:
+        try:
+            # Limits may differ between blocks/channels, so refresh before conversion each cycle.
+            resp = await self._hub.json(f"{self._instance_tag} get bypass {self._channel}")
+            state = resp["value"]
+            if state is not None:
+                self._attr_is_on = _coerce_bool(state)
+                self._attr_available = True
+            else:
+                raise ValueError(f"Could not parse bypass state from response: {resp!r}")
+        except Exception as e:
+            _LOGGER.debug("Update failed for %s: %s", self._attr_unique_id, e)
+            self._attr_available = False
+
+    async def async_turn_on(self) -> None:
+        try:
+            await self._hub.json(f"{self._instance_tag} set bypass {self._channel} true")
+            self._attr_is_on = True
+            self.async_write_ha_state()
+        except Exception as e:
+            _LOGGER.debug("Turn on failed for %s: %s", self._attr_unique_id, e)
+
+    async def async_turn_off(self) -> None:
+        try:
+            await self._hub.json(f"{self._instance_tag} set bypass {self._channel} false")
+            self._attr_is_on = False
+            self.async_write_ha_state()
+        except Exception as e:
+            _LOGGER.debug("Turn off failed for %s: %s", self._attr_unique_id, e)
+
+    async def async_toggle(self) -> None:
+        try:
+            await self._hub.json(f"{self._instance_tag} toggle bypass {self._channel}")
             await self.async_update()  # Refresh state after toggle since we don't know the resulting state in advance.
         except Exception as e:
             _LOGGER.debug("Toggle failed for %s: %s", self._attr_unique_id, e)

--- a/custom_components/tesira_ttp/switch.py
+++ b/custom_components/tesira_ttp/switch.py
@@ -1,8 +1,8 @@
 # #################################################################################################################### #
 # Filename: \custom_components\tesira_ttp\switch.py                                                                    #
 # Repository: tesira_ttp                                                                                               #
-# Created Date: Friday, May 8th 2026, 10:59:43 PM                                                                      #
-# Last Modified: Wednesday, July 8th 2026, 12:09:45 AM                                                                 #
+# Created Date: Tuesday, July 7th 2026, 11:50:58 PM                                                                    #
+# Last Modified: Wednesday, July 8th 2026, 12:36:42 AM                                                                 #
 # Original Author: Darnel Kumar                                                                                        #
 # Author Github: https://github.com/Darnel-K                                                                           #
 #                                                                                                                      #
@@ -41,6 +41,8 @@ from .util import _coerce_bool
 _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities) -> None:
+    """Set up Tesira switch entities for a config entry."""
+
     hubkey = entry.entry_id
     hub: TesiraHub = hass.data[DOMAIN][DICT_KEYS["DATA_HUBS"]][hubkey]
     # devices = copy.deepcopy(entry.data.get(DICT_KEYS["DEVICES"], DEFAULTS["DEVICES"]))

--- a/custom_components/tesira_ttp/switch.py
+++ b/custom_components/tesira_ttp/switch.py
@@ -1,8 +1,8 @@
 # #################################################################################################################### #
 # Filename: \custom_components\tesira_ttp\switch.py                                                                    #
 # Repository: tesira_ttp                                                                                               #
-# Created Date: Thursday, March 19th 2026, 12:56:52 AM                                                                 #
-# Last Modified: Tuesday, July 7th 2026, 11:02:05 PM                                                                   #
+# Created Date: Thursday, April 16th 2026, 11:44:37 PM                                                                 #
+# Last Modified: Tuesday, July 7th 2026, 11:12:04 PM                                                                   #
 # Original Author: Darnel Kumar                                                                                        #
 # Author Github: https://github.com/Darnel-K                                                                           #
 #                                                                                                                      #
@@ -63,6 +63,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
                     entities_list.append(TesiraLogicInputBlock(hub=hub, hubkey=hubkey, entity=entity))
                 case "logic_output":
                     entities_list.append(TesiraLogicOutputBlock(hub=hub, hubkey=hubkey, entity=entity))
+                case "logic_pulse":
+                    entities_list.append(TesiraLogicPulseBlock(hub=hub, hubkey=hubkey, entity=entity))
                 case _:
                     _LOGGER.debug(
                         "Unsupported switch block type '%s' for entity: %s",
@@ -499,6 +501,63 @@ class TesiraLogicSelectorBlock(SwitchEntity):
     async def async_toggle(self) -> None:
         try:
             await self._hub.json(f"{self._instance_tag} toggle {self._channel}")
+            await self.async_update()  # Refresh state after toggle since we don't know the resulting state in advance.
+        except Exception as e:
+            _LOGGER.debug("Toggle failed for %s: %s", self._attr_unique_id, e)
+
+class TesiraLogicPulseBlock(SwitchEntity):
+    """Expose a Tesira logic pulse block as a Home Assistant switch entity."""
+
+    def __init__(self, hub: TesiraHub, hubkey: str, entity: dict[str, Any]) -> None:
+        self._hub = hub
+        self._hubkey = hubkey
+        self._entity = entity
+        self._instance_tag = entity.get(DICT_KEYS["ENTITY_BLOCK_INSTANCE_TAG"])
+        self._block_type = entity.get(DICT_KEYS["ENTITY_BLOCK_TYPE"])
+        self._device_id = entity.get(DICT_KEYS["DEVICE_ID"])
+        self._channel = int(entity.get(DICT_KEYS["ENTITY_BLOCK_CHANNEL"]))
+        self._attr_name = f"Tesira Logic Pulse Block - Tag:{self._instance_tag} - Attr:Indefinite - Chan:{self._channel} ({self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]})"
+        self._attr_unique_id = f"tesira_ttp_{self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]}_{self._block_type}_{self._instance_tag}_indefinite_{self._channel}".lower()
+        self._attr_is_on: bool = False
+        self._attr_available = True
+
+    @property
+    def device_info(self):
+        return {DICT_KEYS["ENTITY_DEVICE_IDENTIFIERS"]: {(DOMAIN, self._device_id)}} if self._device_id != "None" else None
+
+    async def async_update(self) -> None:
+        try:
+            # Limits may differ between blocks/channels, so refresh before conversion each cycle.
+            resp = await self._hub.json(f"{self._instance_tag} get indefinite {self._channel}")
+            state = resp["value"]
+            if state is not None:
+                self._attr_is_on = _coerce_bool(state)
+                self._attr_available = True
+            else:
+                raise ValueError(f"Could not parse indefinite state from response: {resp!r}")
+        except Exception as e:
+            _LOGGER.debug("Update failed for %s: %s", self._attr_unique_id, e)
+            self._attr_available = False
+
+    async def async_turn_on(self) -> None:
+        try:
+            await self._hub.json(f"{self._instance_tag} set indefinite {self._channel} true")
+            self._attr_is_on = True
+            self.async_write_ha_state()
+        except Exception as e:
+            _LOGGER.debug("Turn on failed for %s: %s", self._attr_unique_id, e)
+
+    async def async_turn_off(self) -> None:
+        try:
+            await self._hub.json(f"{self._instance_tag} set indefinite {self._channel} false")
+            self._attr_is_on = False
+            self.async_write_ha_state()
+        except Exception as e:
+            _LOGGER.debug("Turn off failed for %s: %s", self._attr_unique_id, e)
+
+    async def async_toggle(self) -> None:
+        try:
+            await self._hub.json(f"{self._instance_tag} toggle indefinite {self._channel}")
             await self.async_update()  # Refresh state after toggle since we don't know the resulting state in advance.
         except Exception as e:
             _LOGGER.debug("Toggle failed for %s: %s", self._attr_unique_id, e)

--- a/custom_components/tesira_ttp/switch.py
+++ b/custom_components/tesira_ttp/switch.py
@@ -1,8 +1,8 @@
 # #################################################################################################################### #
 # Filename: \custom_components\tesira_ttp\switch.py                                                                    #
 # Repository: tesira_ttp                                                                                               #
-# Created Date: Thursday, April 16th 2026, 11:44:37 PM                                                                 #
-# Last Modified: Tuesday, July 7th 2026, 11:12:04 PM                                                                   #
+# Created Date: Friday, May 8th 2026, 10:59:43 PM                                                                      #
+# Last Modified: Tuesday, July 7th 2026, 11:26:25 PM                                                                   #
 # Original Author: Darnel Kumar                                                                                        #
 # Author Github: https://github.com/Darnel-K                                                                           #
 #                                                                                                                      #
@@ -331,9 +331,9 @@ class TesiraLogicInputBlock(SwitchEntity):
         try:
             # Limits may differ between blocks/channels, so refresh before conversion each cycle.
             resp = await self._hub.json(f"{self._instance_tag} get invert {self._channel}")
-            state = resp["value"]
-            if state is not None:
-                self._attr_is_on = _coerce_bool(state)
+            invert = resp["value"]
+            if invert is not None:
+                self._attr_is_on = _coerce_bool(invert)
                 self._attr_available = True
             else:
                 raise ValueError(f"Could not parse invert state from response: {resp!r}")
@@ -388,9 +388,9 @@ class TesiraLogicOutputBlock(SwitchEntity):
         try:
             # Limits may differ between blocks/channels, so refresh before conversion each cycle.
             resp = await self._hub.json(f"{self._instance_tag} get invert {self._channel}")
-            state = resp["value"]
-            if state is not None:
-                self._attr_is_on = _coerce_bool(state)
+            invert = resp["value"]
+            if invert is not None:
+                self._attr_is_on = _coerce_bool(invert)
                 self._attr_available = True
             else:
                 raise ValueError(f"Could not parse invert state from response: {resp!r}")
@@ -529,9 +529,9 @@ class TesiraLogicPulseBlock(SwitchEntity):
         try:
             # Limits may differ between blocks/channels, so refresh before conversion each cycle.
             resp = await self._hub.json(f"{self._instance_tag} get indefinite {self._channel}")
-            state = resp["value"]
-            if state is not None:
-                self._attr_is_on = _coerce_bool(state)
+            indefinite = resp["value"]
+            if indefinite is not None:
+                self._attr_is_on = _coerce_bool(indefinite)
                 self._attr_available = True
             else:
                 raise ValueError(f"Could not parse indefinite state from response: {resp!r}")


### PR DESCRIPTION
## Summary
This pull request adds broader Tesira logic block support across the Home Assistant integration, including new switch, number, button, and binary sensor entities for supported logic block types. It also expands the shared block schema so these entities can be configured consistently through the existing dynamic options flow.

This PR closes #48 and is associated with #39

## What Changed
- Added switch entity support for additional Tesira logic blocks:
  - `logic_state`
  - `flip_flop`
  - `logic_delay`
  - `logic_input`
  - `logic_output`
  - `logic_selector`
  - `logic_pulse`
  - `logic_sequence`
- Added number entities for configurable logic timing/count values:
  - `logic_delay` on/off delay
  - `logic_pulse` on duration, off duration, pulse count
  - `logic_sequence` on duration, off duration, pulse count
- Added button entities for logic block actions:
  - `logic_pulse` start/stop
  - `logic_sequence` start/stop
- Added binary sensor support for:
  - `logic_pulse` active state
  - `logic_sequence` active state
  - existing logic meter handling remains supported
- Expanded the shared block schema and constants to define these logic block types and their supported entity platforms in one place
- Updated the entity schema builder so field metadata and validator options are derived from the shared declarative block schema
- Bumped the integration version to `0.14.0`

## Implementation Notes
- Logic block entity creation is now driven from the shared `BLOCK_SCHEMA_DATA` definitions, which keeps config validation and runtime entity support aligned
- Logic sequence button entities are treated as block-level actions, while other logic sequence entity types remain channel-based
- Unsupported block types continue to fall through to safe debug logging rather than failing entity setup

## Why
This change extends the integration’s dynamic entity model so Tesira logic blocks can be exposed in Home Assistant with the right entity type for the underlying DSP behavior:
- switches for toggled or invertible states
- numbers for timing and count parameters
- buttons for start/stop actions
- binary sensors for active/state monitoring

## Impact
- Users can configure and expose more Tesira logic block functionality without adding one-off platform-specific schema logic
- Configuration behavior becomes more consistent because supported fields and entity types are declared centrally
- The integration now covers a substantially larger portion of common Tesira logic workflows from Home Assistant

## Testing
- Verified implementation by reviewing the entity setup paths and shared schema wiring for the newly added logic block types
- No automated test suite was run as part of this branch

## Issues
Closes #48  
Related to #39