### PR TITLE
feat(meter-blocks): add comprehensive Tesira meter block support with…

### DIFF
--- a/custom_components/tesira_ttp/binary_sensor.py
+++ b/custom_components/tesira_ttp/binary_sensor.py
@@ -1,8 +1,8 @@
 # #################################################################################################################### #
 # Filename: \custom_components\tesira_ttp\binary_sensor.py                                                             #
 # Repository: tesira_ttp                                                                                               #
-# Created Date: Thursday, March 19th 2026, 12:56:52 AM                                                                 #
-# Last Modified: Wednesday, July 8th 2026, 1:23:41 AM                                                                  #
+# Created Date: Wednesday, July 8th 2026, 1:46:51 AM                                                                   #
+# Last Modified: Monday, July 13th 2026, 11:58:54 PM                                                                   #
 # Original Author: Darnel Kumar                                                                                        #
 # Author Github: https://github.com/Darnel-K                                                                           #
 #                                                                                                                      #
@@ -56,11 +56,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
         if "binary_sensor" in entity[DICT_KEYS["ENTITY_BLOCK_SUPPORTED_TYPES"]]:
             match entity[DICT_KEYS["ENTITY_BLOCK_TYPE"]]:
                 case "logic_meter":
-                    entities_list.append(TesiraLogicMeterBlock(hub=hub, hubkey=hubkey, entity=entity))
+                    entities_list.append(TesiraLogicMeterBlockState(hub=hub, hubkey=hubkey, entity=entity))
                 case "logic_pulse":
                     entities_list.append(TesiraLogicPulseBlockActive(hub=hub, hubkey=hubkey, entity=entity))
                 case "logic_sequence":
                     entities_list.append(TesiraLogicSequenceBlockActive(hub=hub, hubkey=hubkey, entity=entity))
+                case "signal_present_meter":
+                    entities_list.append(TesiraSignalPresentMeterBlockLogicState(hub=hub, hubkey=hubkey, entity=entity))
+                    entities_list.append(TesiraSignalPresentMeterBlockPresence(hub=hub, hubkey=hubkey, entity=entity))
                 case _:
                     _LOGGER.debug(
                         "Unsupported binary sensor block type '%s' for entity: %s",
@@ -152,8 +155,8 @@ class TesiraHubConnBinarySensor(BinarySensorEntity):
         # Reflect the client session state managed by TesiraHub/TesiraClient.
         self._attr_is_on = self._hub.is_connected
 
-class TesiraLogicMeterBlock(BinarySensorEntity):
-    """Expose a Tesira logic meter block as a Home Assistant binary sensor entity."""
+class TesiraLogicMeterBlockState(BinarySensorEntity):
+    """Expose a Tesira logic meter block (State) as a Home Assistant binary sensor entity."""
 
     def __init__(self, hub: TesiraHub, hubkey: str, entity: dict[str, Any]) -> None:
         self._hub = hub
@@ -193,11 +196,11 @@ class TesiraLogicMeterBlock(BinarySensorEntity):
         if self._sub:
             # Prime state once before starting subscriptions to avoid an empty initial UI state.
             await self.async_update()
-            await self._hub.subscribe(self._instance_tag, "state", self._channel, f"hass_switch_level_meter_{self._instance_tag}_{self._channel}", 100, self._update_state_from_sub)
+            await self._hub.subscribe(self._instance_tag, "state", self._channel, f"hass_binary_sensor_logic_meter_state_{self._instance_tag}_{self._channel}", 100, self._update_state_from_sub)
 
     async def async_will_remove_from_hass(self) -> None:
         if self._sub:
-            await self._hub.unsubscribe(f"hass_switch_level_meter_{self._instance_tag}_{self._channel}")
+            await self._hub.unsubscribe(f"hass_binary_sensor_logic_meter_state_{self._instance_tag}_{self._channel}")
 
     async def async_update(self) -> None:
         try:
@@ -277,6 +280,101 @@ class TesiraLogicSequenceBlockActive(BinarySensorEntity):
                 self._attr_available = True
             else:
                 raise ValueError(f"Could not parse active state from response: {resp!r}")
+        except Exception as e:
+            _LOGGER.debug("Update failed for %s: %s", self._attr_unique_id, e)
+            self._attr_available = False
+
+class TesiraSignalPresentMeterBlockLogicState(BinarySensorEntity):
+    """Expose a Tesira signal present meter block (Logic State) as a Home Assistant binary sensor entity."""
+
+    def __init__(self, hub: TesiraHub, hubkey: str, entity: dict[str, Any]) -> None:
+        self._hub = hub
+        self._hubkey = hubkey
+        self._entity = entity
+        self._instance_tag = entity.get(DICT_KEYS["ENTITY_BLOCK_INSTANCE_TAG"])
+        self._block_type = entity.get(DICT_KEYS["ENTITY_BLOCK_TYPE"])
+        self._device_id = entity.get(DICT_KEYS["DEVICE_ID"])
+        self._channel = int(entity.get(DICT_KEYS["ENTITY_BLOCK_CHANNEL"]))
+        self._attr_name = f"Tesira Signal Present Meter Block - Tag:{self._instance_tag} - Attr:LogicState - Chan:{self._channel} ({self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]})"
+        self._attr_unique_id = f"tesira_ttp_{self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]}_{self._block_type}_{self._instance_tag}_logicstate_{self._channel}".lower()
+        self._attr_is_on: bool = False
+        self._attr_available = True
+
+    @property
+    def device_info(self):
+        return {DICT_KEYS["ENTITY_DEVICE_IDENTIFIERS"]: {(DOMAIN, self._device_id)}} if self._device_id != "None" else None
+
+    async def async_update(self) -> None:
+        try:
+            # Limits may differ between blocks/channels, so refresh before conversion each cycle.
+            resp = await self._hub.json(f"{self._instance_tag} get logicstate {self._channel}")
+            logicstate = resp["value"]
+            if logicstate is not None:
+                self._attr_is_on = _coerce_bool(logicstate)
+                self._attr_available = True
+            else:
+                raise ValueError(f"Could not parse logic state from response: {resp!r}")
+        except Exception as e:
+            _LOGGER.debug("Update failed for %s: %s", self._attr_unique_id, e)
+            self._attr_available = False
+
+class TesiraSignalPresentMeterBlockPresence(BinarySensorEntity):
+    """Expose a Tesira signal present meter block (Presence) as a Home Assistant binary sensor entity."""
+
+    def __init__(self, hub: TesiraHub, hubkey: str, entity: dict[str, Any]) -> None:
+        self._hub = hub
+        self._hubkey = hubkey
+        self._entity = entity
+        self._instance_tag = entity.get(DICT_KEYS["ENTITY_BLOCK_INSTANCE_TAG"])
+        self._block_type = entity.get(DICT_KEYS["ENTITY_BLOCK_TYPE"])
+        self._device_id = entity.get(DICT_KEYS["DEVICE_ID"])
+        self._channel = int(entity.get(DICT_KEYS["ENTITY_BLOCK_CHANNEL"]))
+        self._sub = entity.get(DICT_KEYS["ENTITY_BLOCK_SUBSCRIBE"])
+        self._attr_name = f"Tesira Signal Present Meter Block - Tag:{self._instance_tag} - Attr:Present - Chan:{self._channel} ({self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]})"
+        self._attr_unique_id = f"tesira_ttp_{self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]}_{self._block_type}_{self._instance_tag}_present_{self._channel}".lower()
+        self._attr_is_on: bool = False
+        self._attr_available = True
+
+        if self._sub:
+            # Subscription mode pushes updates from the DSP, so polling is unnecessary.
+            self._attr_should_poll = False
+        else:
+            self._attr_should_poll = True
+
+    @property
+    def device_info(self):
+        return {DICT_KEYS["ENTITY_DEVICE_IDENTIFIERS"]: {(DOMAIN, self._device_id)}} if self._device_id != "None" else None
+
+    def _update_state_from_sub(self, data: dict) -> None:
+        presence = data.get("value")
+        if presence is not None:
+            self._attr_is_on = _coerce_bool(presence)
+            self._attr_available = True
+            self._hass.loop.call_soon_threadsafe(self.async_write_ha_state)
+        else:
+            _LOGGER.warning("Received subscription update without presence value: %s", data)
+
+    async def async_added_to_hass(self) -> None:
+        self._hass = self.hass
+        if self._sub:
+            # Prime state once before starting subscriptions to avoid an empty initial UI state.
+            await self.async_update()
+            await self._hub.subscribe(self._instance_tag, "present", self._channel, f"hass_binary_sensor_signal_present_meter_present_{self._instance_tag}_{self._channel}", 100, self._update_state_from_sub)
+
+    async def async_will_remove_from_hass(self) -> None:
+        if self._sub:
+            await self._hub.unsubscribe(f"hass_binary_sensor_signal_present_meter_present_{self._instance_tag}_{self._channel}")
+
+    async def async_update(self) -> None:
+        try:
+            # Limits may differ between blocks/channels, so refresh before conversion each cycle.
+            resp = await self._hub.json(f"{self._instance_tag} get present {self._channel}")
+            present = resp["value"]
+            if present is not None:
+                self._attr_is_on = _coerce_bool(present)
+                self._attr_available = True
+            else:
+                raise ValueError(f"Could not parse presence from response: {resp!r}")
         except Exception as e:
             _LOGGER.debug("Update failed for %s: %s", self._attr_unique_id, e)
             self._attr_available = False

--- a/custom_components/tesira_ttp/const.py
+++ b/custom_components/tesira_ttp/const.py
@@ -1,8 +1,8 @@
 # #################################################################################################################### #
 # Filename: \custom_components\tesira_ttp\const.py                                                                     #
 # Repository: tesira_ttp                                                                                               #
-# Created Date: Thursday, March 19th 2026, 12:56:52 AM                                                                 #
-# Last Modified: Wednesday, July 8th 2026, 1:27:02 AM                                                                  #
+# Created Date: Thursday, April 16th 2026, 11:44:37 PM                                                                 #
+# Last Modified: Monday, July 13th 2026, 11:36:27 PM                                                                   #
 # Original Author: Darnel Kumar                                                                                        #
 # Author Github: https://github.com/Darnel-K                                                                           #
 #                                                                                                                      #
@@ -27,7 +27,7 @@ from __future__ import annotations
 from homeassistant.const import Platform
 
 DOMAIN = "tesira_ttp"
-PLATFORMS: list[Platform] = [Platform.MEDIA_PLAYER, Platform.BINARY_SENSOR, Platform.SWITCH, Platform.NUMBER, Platform.BUTTON]
+PLATFORMS: list[Platform] = [Platform.MEDIA_PLAYER, Platform.BINARY_SENSOR, Platform.SWITCH, Platform.NUMBER, Platform.BUTTON, Platform.SELECT, Platform.SENSOR]
 
 DICT_KEYS = {
     "DATA_HUBS": "hubs",
@@ -177,6 +177,24 @@ BLOCK_SCHEMA_DATA = {
         },
         DICT_KEYS["ENTITY_BLOCK_SUPPORTED_TYPES"]: ["binary_sensor", "switch", "number", "button"],
         DICT_KEYS["ENTITY_BLOCK_FIELDS"]: [DICT_KEYS["DEVICE_ID"], DICT_KEYS["ENTITY_BLOCK_INSTANCE_TAG"], DICT_KEYS["ENTITY_BLOCK_CHANNEL"], DICT_KEYS["ENTITY_MIN_VALUE"], DICT_KEYS["ENTITY_MAX_VALUE"]]
+    },
+    "audio_meter": {
+        "label": "Audio Meter",
+        DICT_KEYS["ENTITY_BLOCK_FIELD_OPTIONS"]: {
+            DICT_KEYS["ENTITY_MIN_VALUE"]: {"min": 0, "max": 1000, DICT_KEYS["ENTITY_FIELD_TYPE_OVERRIDE"]: "integer"},
+            DICT_KEYS["ENTITY_MAX_VALUE"]: {"min": 0, "max": 1000, DICT_KEYS["ENTITY_FIELD_TYPE_OVERRIDE"]: "integer"}
+        },
+        DICT_KEYS["ENTITY_BLOCK_SUPPORTED_TYPES"]: ["switch", "number", "select", "sensor"],
+        DICT_KEYS["ENTITY_BLOCK_FIELDS"]: [DICT_KEYS["DEVICE_ID"], DICT_KEYS["ENTITY_BLOCK_INSTANCE_TAG"], DICT_KEYS["ENTITY_BLOCK_CHANNEL"], DICT_KEYS["ENTITY_MIN_VALUE"], DICT_KEYS["ENTITY_MAX_VALUE"], DICT_KEYS["ENTITY_BLOCK_SUBSCRIBE"]]
+    },
+    "signal_present_meter": {
+        "label": "Signal Present Meter",
+        DICT_KEYS["ENTITY_BLOCK_FIELD_OPTIONS"]: {
+            DICT_KEYS["ENTITY_MIN_VALUE"]: {"min": -64, "max": 60000, DICT_KEYS["ENTITY_FIELD_TYPE_OVERRIDE"]: "integer"},
+            DICT_KEYS["ENTITY_MAX_VALUE"]: {"min": -64, "max": 60000, DICT_KEYS["ENTITY_FIELD_TYPE_OVERRIDE"]: "integer"}
+        },
+        DICT_KEYS["ENTITY_BLOCK_SUPPORTED_TYPES"]: ["switch", "number", "sensor", "binary_sensor"],
+        DICT_KEYS["ENTITY_BLOCK_FIELDS"]: [DICT_KEYS["DEVICE_ID"], DICT_KEYS["ENTITY_BLOCK_INSTANCE_TAG"], DICT_KEYS["ENTITY_BLOCK_CHANNEL"], DICT_KEYS["ENTITY_MIN_VALUE"], DICT_KEYS["ENTITY_MAX_VALUE"], DICT_KEYS["ENTITY_BLOCK_SUBSCRIBE"]]
     }
 }
 

--- a/custom_components/tesira_ttp/manifest.json
+++ b/custom_components/tesira_ttp/manifest.json
@@ -19,5 +19,5 @@
         "fido2>=1.2.0",
         "prompt_toolkit>=3.0.52"
     ],
-    "version": "0.14.0"
+    "version": "0.15.3"
 }

--- a/custom_components/tesira_ttp/number.py
+++ b/custom_components/tesira_ttp/number.py
@@ -1,8 +1,8 @@
 # #################################################################################################################### #
 # Filename: \custom_components\tesira_ttp\number.py                                                                    #
 # Repository: tesira_ttp                                                                                               #
-# Created Date: Tuesday, July 7th 2026, 11:50:58 PM                                                                    #
-# Last Modified: Wednesday, July 8th 2026, 12:36:42 AM                                                                 #
+# Created Date: Thursday, April 16th 2026, 11:44:37 PM                                                                 #
+# Last Modified: Tuesday, July 14th 2026, 12:17:57 AM                                                                  #
 # Original Author: Darnel Kumar                                                                                        #
 # Author Github: https://github.com/Darnel-K                                                                           #
 #                                                                                                                      #
@@ -52,8 +52,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
         if "number" in entity[DICT_KEYS["ENTITY_BLOCK_SUPPORTED_TYPES"]]:
             match entity[DICT_KEYS["ENTITY_BLOCK_TYPE"]]:
                 case "logic_delay":
-                    entities_list.append(TesiraLogicDelayBlockOn(hub=hub, hubkey=hubkey, entity=entity))
-                    entities_list.append(TesiraLogicDelayBlockOff(hub=hub, hubkey=hubkey, entity=entity))
+                    entities_list.append(TesiraLogicDelayBlockOnDelay(hub=hub, hubkey=hubkey, entity=entity))
+                    entities_list.append(TesiraLogicDelayBlockOffDelay(hub=hub, hubkey=hubkey, entity=entity))
                 case "logic_pulse":
                     entities_list.append(TesiraLogicPulseBlockOnDuration(hub=hub, hubkey=hubkey, entity=entity))
                     entities_list.append(TesiraLogicPulseBlockOffDuration(hub=hub, hubkey=hubkey, entity=entity))
@@ -62,6 +62,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
                     entities_list.append(TesiraLogicSequenceBlockOnDuration(hub=hub, hubkey=hubkey, entity=entity))
                     entities_list.append(TesiraLogicSequenceBlockOffDuration(hub=hub, hubkey=hubkey, entity=entity))
                     entities_list.append(TesiraLogicSequenceBlockPulseCount(hub=hub, hubkey=hubkey, entity=entity))
+                case "audio_meter":
+                    entities_list.append(TesiraAudioMeterBlockHoldTime(hub=hub, hubkey=hubkey, entity=entity))
+                case "signal_present_meter":
+                    entities_list.append(TesiraSignalPresentMeterBlockOffDelay(hub=hub, hubkey=hubkey, entity=entity))
+                    entities_list.append(TesiraSignalPresentMeterBlockOnDelay(hub=hub, hubkey=hubkey, entity=entity))
+                    entities_list.append(TesiraSignalPresentMeterBlockThreshold(hub=hub, hubkey=hubkey, entity=entity))
                 case _:
                     _LOGGER.debug(
                         "Unsupported number block type '%s' for entity: %s",
@@ -79,8 +85,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
 
     async_add_entities(entities_list, update_before_add=True)
 
-class TesiraLogicDelayBlockOn(NumberEntity):
-    """Expose a Tesira logic delay block (On) as a Home Assistant number entity."""
+class TesiraLogicDelayBlockOnDelay(NumberEntity):
+    """Expose a Tesira logic delay block (On Delay) as a Home Assistant number entity."""
 
     def __init__(self, hub: TesiraHub, hubkey: str, entity: dict[str, Any]) -> None:
         self._hub = hub
@@ -115,7 +121,7 @@ class TesiraLogicDelayBlockOn(NumberEntity):
                 self._attr_native_value = delay
                 self._attr_available = True
             else:
-                raise ValueError(f"Could not parse state from response: {resp!r}")
+                raise ValueError(f"Could not parse delay from response: {resp!r}")
         except Exception as e:
             _LOGGER.debug("Update failed for %s: %s", self._attr_unique_id, e)
             self._attr_available = False
@@ -126,10 +132,10 @@ class TesiraLogicDelayBlockOn(NumberEntity):
             self._attr_is_on = True
             self.async_write_ha_state()
         except Exception as e:
-            _LOGGER.debug("Failed to set native value for %s: %s", self._attr_unique_id, e)
+            _LOGGER.debug("Failed to set delay for %s: %s", self._attr_unique_id, e)
 
-class TesiraLogicDelayBlockOff(NumberEntity):
-    """Expose a Tesira logic delay block (Off) as a Home Assistant number entity."""
+class TesiraLogicDelayBlockOffDelay(NumberEntity):
+    """Expose a Tesira logic delay block (Off Delay) as a Home Assistant number entity."""
 
     def __init__(self, hub: TesiraHub, hubkey: str, entity: dict[str, Any]) -> None:
         self._hub = hub
@@ -164,7 +170,7 @@ class TesiraLogicDelayBlockOff(NumberEntity):
                 self._attr_native_value = delay
                 self._attr_available = True
             else:
-                raise ValueError(f"Could not parse state from response: {resp!r}")
+                raise ValueError(f"Could not parse delay from response: {resp!r}")
         except Exception as e:
             _LOGGER.debug("Update failed for %s: %s", self._attr_unique_id, e)
             self._attr_available = False
@@ -175,7 +181,7 @@ class TesiraLogicDelayBlockOff(NumberEntity):
             self._attr_is_on = True
             self.async_write_ha_state()
         except Exception as e:
-            _LOGGER.debug("Failed to set native value for %s: %s", self._attr_unique_id, e)
+            _LOGGER.debug("Failed to set delay for %s: %s", self._attr_unique_id, e)
 
 class TesiraLogicPulseBlockOffDuration(NumberEntity):
     """Expose a Tesira logic pulse block (Off Duration) as a Home Assistant number entity."""
@@ -213,7 +219,7 @@ class TesiraLogicPulseBlockOffDuration(NumberEntity):
                 self._attr_native_value = off_duration
                 self._attr_available = True
             else:
-                raise ValueError(f"Could not parse state from response: {resp!r}")
+                raise ValueError(f"Could not parse duration from response: {resp!r}")
         except Exception as e:
             _LOGGER.debug("Update failed for %s: %s", self._attr_unique_id, e)
             self._attr_available = False
@@ -224,7 +230,7 @@ class TesiraLogicPulseBlockOffDuration(NumberEntity):
             self._attr_is_on = True
             self.async_write_ha_state()
         except Exception as e:
-            _LOGGER.debug("Failed to set native value for %s: %s", self._attr_unique_id, e)
+            _LOGGER.debug("Failed to set duration for %s: %s", self._attr_unique_id, e)
 
 class TesiraLogicPulseBlockOnDuration(NumberEntity):
     """Expose a Tesira logic pulse block (On Duration) as a Home Assistant number entity."""
@@ -262,7 +268,7 @@ class TesiraLogicPulseBlockOnDuration(NumberEntity):
                 self._attr_native_value = on_duration
                 self._attr_available = True
             else:
-                raise ValueError(f"Could not parse state from response: {resp!r}")
+                raise ValueError(f"Could not parse duration from response: {resp!r}")
         except Exception as e:
             _LOGGER.debug("Update failed for %s: %s", self._attr_unique_id, e)
             self._attr_available = False
@@ -273,7 +279,7 @@ class TesiraLogicPulseBlockOnDuration(NumberEntity):
             self._attr_is_on = True
             self.async_write_ha_state()
         except Exception as e:
-            _LOGGER.debug("Failed to set native value for %s: %s", self._attr_unique_id, e)
+            _LOGGER.debug("Failed to set duration for %s: %s", self._attr_unique_id, e)
 
 class TesiraLogicPulseBlockPulseCount(NumberEntity):
     """Expose a Tesira logic pulse block (Pulse Count) as a Home Assistant number entity."""
@@ -309,7 +315,7 @@ class TesiraLogicPulseBlockPulseCount(NumberEntity):
                 self._attr_native_value = pulse_count
                 self._attr_available = True
             else:
-                raise ValueError(f"Could not parse state from response: {resp!r}")
+                raise ValueError(f"Could not parse pulse count from response: {resp!r}")
         except Exception as e:
             _LOGGER.debug("Update failed for %s: %s", self._attr_unique_id, e)
             self._attr_available = False
@@ -320,7 +326,7 @@ class TesiraLogicPulseBlockPulseCount(NumberEntity):
             self._attr_is_on = True
             self.async_write_ha_state()
         except Exception as e:
-            _LOGGER.debug("Failed to set native value for %s: %s", self._attr_unique_id, e)
+            _LOGGER.debug("Failed to set pulse count for %s: %s", self._attr_unique_id, e)
 
 class TesiraLogicSequenceBlockOffDuration(NumberEntity):
     """Expose a Tesira logic sequence block (Off Duration) as a Home Assistant number entity."""
@@ -358,7 +364,7 @@ class TesiraLogicSequenceBlockOffDuration(NumberEntity):
                 self._attr_native_value = off_duration
                 self._attr_available = True
             else:
-                raise ValueError(f"Could not parse state from response: {resp!r}")
+                raise ValueError(f"Could not parse duration from response: {resp!r}")
         except Exception as e:
             _LOGGER.debug("Update failed for %s: %s", self._attr_unique_id, e)
             self._attr_available = False
@@ -369,7 +375,7 @@ class TesiraLogicSequenceBlockOffDuration(NumberEntity):
             self._attr_is_on = True
             self.async_write_ha_state()
         except Exception as e:
-            _LOGGER.debug("Failed to set native value for %s: %s", self._attr_unique_id, e)
+            _LOGGER.debug("Failed to set duration for %s: %s", self._attr_unique_id, e)
 
 class TesiraLogicSequenceBlockOnDuration(NumberEntity):
     """Expose a Tesira logic sequence block (On Duration) as a Home Assistant number entity."""
@@ -407,7 +413,7 @@ class TesiraLogicSequenceBlockOnDuration(NumberEntity):
                 self._attr_native_value = on_duration
                 self._attr_available = True
             else:
-                raise ValueError(f"Could not parse state from response: {resp!r}")
+                raise ValueError(f"Could not parse duration from response: {resp!r}")
         except Exception as e:
             _LOGGER.debug("Update failed for %s: %s", self._attr_unique_id, e)
             self._attr_available = False
@@ -418,7 +424,7 @@ class TesiraLogicSequenceBlockOnDuration(NumberEntity):
             self._attr_is_on = True
             self.async_write_ha_state()
         except Exception as e:
-            _LOGGER.debug("Failed to set native value for %s: %s", self._attr_unique_id, e)
+            _LOGGER.debug("Failed to set duration for %s: %s", self._attr_unique_id, e)
 
 class TesiraLogicSequenceBlockPulseCount(NumberEntity):
     """Expose a Tesira logic sequence block (Pulse Count) as a Home Assistant number entity."""
@@ -454,7 +460,7 @@ class TesiraLogicSequenceBlockPulseCount(NumberEntity):
                 self._attr_native_value = pulse_count
                 self._attr_available = True
             else:
-                raise ValueError(f"Could not parse state from response: {resp!r}")
+                raise ValueError(f"Could not parse pulse count from response: {resp!r}")
         except Exception as e:
             _LOGGER.debug("Update failed for %s: %s", self._attr_unique_id, e)
             self._attr_available = False
@@ -465,4 +471,200 @@ class TesiraLogicSequenceBlockPulseCount(NumberEntity):
             self._attr_is_on = True
             self.async_write_ha_state()
         except Exception as e:
-            _LOGGER.debug("Failed to set native value for %s: %s", self._attr_unique_id, e)
+            _LOGGER.debug("Failed to set pulse count for %s: %s", self._attr_unique_id, e)
+
+class TesiraAudioMeterBlockHoldTime(NumberEntity):
+    """Expose a Tesira audio meter block (Hold Time) as a Home Assistant number entity."""
+
+    def __init__(self, hub: TesiraHub, hubkey: str, entity: dict[str, Any]) -> None:
+        self._hub = hub
+        self._hubkey = hubkey
+        self._entity = entity
+        self._instance_tag = entity.get(DICT_KEYS["ENTITY_BLOCK_INSTANCE_TAG"])
+        self._block_type = entity.get(DICT_KEYS["ENTITY_BLOCK_TYPE"])
+        self._device_id = entity.get(DICT_KEYS["DEVICE_ID"])
+        self._channel = int(entity.get(DICT_KEYS["ENTITY_BLOCK_CHANNEL"]))
+        self._min_value = int(entity.get(DICT_KEYS["ENTITY_MIN_VALUE"]))
+        self._max_value = int(entity.get(DICT_KEYS["ENTITY_MAX_VALUE"]))
+        self._attr_name = f"Tesira Audio Meter Block - Tag:{self._instance_tag} - Attr:HoldTime - Chan:{self._channel} ({self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]})"
+        self._attr_unique_id = f"tesira_ttp_{self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]}_{self._block_type}_{self._instance_tag}_holdtime_{self._channel}".lower()
+        self._attr_mode = "box"
+        self._attr_native_step = 1
+        self._attr_native_max_value = self._max_value
+        self._attr_native_min_value = self._min_value
+        self._attr_device_class = NumberDeviceClass.DURATION
+        self._attr_native_unit_of_measurement = "ms"
+        self._attr_available = True
+
+    @property
+    def device_info(self):
+        return {DICT_KEYS["ENTITY_DEVICE_IDENTIFIERS"]: {(DOMAIN, self._device_id)}} if self._device_id != "None" else None
+
+    async def async_update(self) -> None:
+        try:
+            # Limits may differ between blocks/channels, so refresh before conversion each cycle.
+            resp = await self._hub.json(f"{self._instance_tag} get holdTime {self._channel}")
+            hold_time = resp["value"]
+            if hold_time is not None:
+                self._attr_native_value = hold_time
+                self._attr_available = True
+            else:
+                raise ValueError(f"Could not parse hold time from response: {resp!r}")
+        except Exception as e:
+            _LOGGER.debug("Update failed for %s: %s", self._attr_unique_id, e)
+            self._attr_available = False
+
+    async def async_set_native_value(self, value: int) -> None:
+        try:
+            await self._hub.json(f"{self._instance_tag} set holdTime {self._channel} {value}")
+            self._attr_is_on = True
+            self.async_write_ha_state()
+        except Exception as e:
+            _LOGGER.debug("Failed to set hold time for %s: %s", self._attr_unique_id, e)
+
+class TesiraSignalPresentMeterBlockOffDelay(NumberEntity):
+    """Expose a Tesira signal present meter block (Off Delay) as a Home Assistant number entity."""
+
+    def __init__(self, hub: TesiraHub, hubkey: str, entity: dict[str, Any]) -> None:
+        self._hub = hub
+        self._hubkey = hubkey
+        self._entity = entity
+        self._instance_tag = entity.get(DICT_KEYS["ENTITY_BLOCK_INSTANCE_TAG"])
+        self._block_type = entity.get(DICT_KEYS["ENTITY_BLOCK_TYPE"])
+        self._device_id = entity.get(DICT_KEYS["DEVICE_ID"])
+        self._channel = int(entity.get(DICT_KEYS["ENTITY_BLOCK_CHANNEL"]))
+        self._min_value = int(entity.get(DICT_KEYS["ENTITY_MIN_VALUE"])) if int(entity.get(DICT_KEYS["ENTITY_MIN_VALUE"])) >= 0 else 0
+        self._max_value = int(entity.get(DICT_KEYS["ENTITY_MAX_VALUE"])) if int(entity.get(DICT_KEYS["ENTITY_MAX_VALUE"])) <= 60000 else 60000
+        self._attr_name = f"Tesira Signal Present Meter Block - Tag:{self._instance_tag} - Attr:OffDelay - Chan:{self._channel} ({self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]})"
+        self._attr_unique_id = f"tesira_ttp_{self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]}_{self._block_type}_{self._instance_tag}_offdelay_{self._channel}".lower()
+        self._attr_mode = "box"
+        self._attr_native_step = 1
+        self._attr_native_max_value = self._max_value
+        self._attr_native_min_value = self._min_value
+        self._attr_device_class = NumberDeviceClass.DURATION
+        self._attr_native_unit_of_measurement = "ms"
+        self._attr_available = True
+
+    @property
+    def device_info(self):
+        return {DICT_KEYS["ENTITY_DEVICE_IDENTIFIERS"]: {(DOMAIN, self._device_id)}} if self._device_id != "None" else None
+
+    async def async_update(self) -> None:
+        try:
+            # Limits may differ between blocks/channels, so refresh before conversion each cycle.
+            resp = await self._hub.json(f"{self._instance_tag} get offDelay {self._channel}")
+            delay = resp["value"]
+            if delay is not None:
+                self._attr_native_value = delay
+                self._attr_available = True
+            else:
+                raise ValueError(f"Could not parse delay from response: {resp!r}")
+        except Exception as e:
+            _LOGGER.debug("Update failed for %s: %s", self._attr_unique_id, e)
+            self._attr_available = False
+
+    async def async_set_native_value(self, value: int) -> None:
+        try:
+            await self._hub.json(f"{self._instance_tag} set offDelay {self._channel} {value}")
+            self._attr_is_on = True
+            self.async_write_ha_state()
+        except Exception as e:
+            _LOGGER.debug("Failed to set delay for %s: %s", self._attr_unique_id, e)
+
+class TesiraSignalPresentMeterBlockOnDelay(NumberEntity):
+    """Expose a Tesira signal present meter block (On Delay) as a Home Assistant number entity."""
+
+    def __init__(self, hub: TesiraHub, hubkey: str, entity: dict[str, Any]) -> None:
+        self._hub = hub
+        self._hubkey = hubkey
+        self._entity = entity
+        self._instance_tag = entity.get(DICT_KEYS["ENTITY_BLOCK_INSTANCE_TAG"])
+        self._block_type = entity.get(DICT_KEYS["ENTITY_BLOCK_TYPE"])
+        self._device_id = entity.get(DICT_KEYS["DEVICE_ID"])
+        self._channel = int(entity.get(DICT_KEYS["ENTITY_BLOCK_CHANNEL"]))
+        self._min_value = int(entity.get(DICT_KEYS["ENTITY_MIN_VALUE"])) if int(entity.get(DICT_KEYS["ENTITY_MIN_VALUE"])) >= 0 else 0
+        self._max_value = int(entity.get(DICT_KEYS["ENTITY_MAX_VALUE"])) if int(entity.get(DICT_KEYS["ENTITY_MAX_VALUE"])) <= 60000 else 60000
+        self._attr_name = f"Tesira Signal Present Meter Block - Tag:{self._instance_tag} - Attr:OnDelay - Chan:{self._channel} ({self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]})"
+        self._attr_unique_id = f"tesira_ttp_{self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]}_{self._block_type}_{self._instance_tag}_ondelay_{self._channel}".lower()
+        self._attr_mode = "box"
+        self._attr_native_step = 1
+        self._attr_native_max_value = self._max_value
+        self._attr_native_min_value = self._min_value
+        self._attr_device_class = NumberDeviceClass.DURATION
+        self._attr_native_unit_of_measurement = "ms"
+        self._attr_available = True
+
+    @property
+    def device_info(self):
+        return {DICT_KEYS["ENTITY_DEVICE_IDENTIFIERS"]: {(DOMAIN, self._device_id)}} if self._device_id != "None" else None
+
+    async def async_update(self) -> None:
+        try:
+            # Limits may differ between blocks/channels, so refresh before conversion each cycle.
+            resp = await self._hub.json(f"{self._instance_tag} get onDelay {self._channel}")
+            delay = resp["value"]
+            if delay is not None:
+                self._attr_native_value = delay
+                self._attr_available = True
+            else:
+                raise ValueError(f"Could not parse delay from response: {resp!r}")
+        except Exception as e:
+            _LOGGER.debug("Update failed for %s: %s", self._attr_unique_id, e)
+            self._attr_available = False
+
+    async def async_set_native_value(self, value: int) -> None:
+        try:
+            await self._hub.json(f"{self._instance_tag} set onDelay {self._channel} {value}")
+            self._attr_is_on = True
+            self.async_write_ha_state()
+        except Exception as e:
+            _LOGGER.debug("Failed to set delay for %s: %s", self._attr_unique_id, e)
+
+class TesiraSignalPresentMeterBlockThreshold(NumberEntity):
+    """Expose a Tesira signal present meter block (Threshold) as a Home Assistant number entity."""
+
+    def __init__(self, hub: TesiraHub, hubkey: str, entity: dict[str, Any]) -> None:
+        self._hub = hub
+        self._hubkey = hubkey
+        self._entity = entity
+        self._instance_tag = entity.get(DICT_KEYS["ENTITY_BLOCK_INSTANCE_TAG"])
+        self._block_type = entity.get(DICT_KEYS["ENTITY_BLOCK_TYPE"])
+        self._device_id = entity.get(DICT_KEYS["DEVICE_ID"])
+        self._channel = int(entity.get(DICT_KEYS["ENTITY_BLOCK_CHANNEL"]))
+        self._min_value = int(entity.get(DICT_KEYS["ENTITY_MIN_VALUE"])) if int(entity.get(DICT_KEYS["ENTITY_MIN_VALUE"])) >= -64 else -64
+        self._max_value = int(entity.get(DICT_KEYS["ENTITY_MAX_VALUE"])) if int(entity.get(DICT_KEYS["ENTITY_MAX_VALUE"])) <= 30 else 30
+        self._attr_name = f"Tesira Signal Present Meter Block - Tag:{self._instance_tag} - Attr:Threshold - Chan:{self._channel} ({self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]})"
+        self._attr_unique_id = f"tesira_ttp_{self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]}_{self._block_type}_{self._instance_tag}_threshold_{self._channel}".lower()
+        self._attr_mode = "box"
+        self._attr_native_step = 1
+        self._attr_native_max_value = self._max_value
+        self._attr_native_min_value = self._min_value
+        self._attr_device_class = NumberDeviceClass.DURATION
+        self._attr_native_unit_of_measurement = "ms"
+        self._attr_available = True
+
+    @property
+    def device_info(self):
+        return {DICT_KEYS["ENTITY_DEVICE_IDENTIFIERS"]: {(DOMAIN, self._device_id)}} if self._device_id != "None" else None
+
+    async def async_update(self) -> None:
+        try:
+            # Limits may differ between blocks/channels, so refresh before conversion each cycle.
+            resp = await self._hub.json(f"{self._instance_tag} get threshold {self._channel}")
+            threshold = resp["value"]
+            if threshold is not None:
+                self._attr_native_value = threshold
+                self._attr_available = True
+            else:
+                raise ValueError(f"Could not parse threshold from response: {resp!r}")
+        except Exception as e:
+            _LOGGER.debug("Update failed for %s: %s", self._attr_unique_id, e)
+            self._attr_available = False
+
+    async def async_set_native_value(self, value: int) -> None:
+        try:
+            await self._hub.json(f"{self._instance_tag} set threshold {self._channel} {value}")
+            self._attr_is_on = True
+            self.async_write_ha_state()
+        except Exception as e:
+            _LOGGER.debug("Failed to set threshold for %s: %s", self._attr_unique_id, e)

--- a/custom_components/tesira_ttp/select.py
+++ b/custom_components/tesira_ttp/select.py
@@ -1,0 +1,118 @@
+# #################################################################################################################### #
+# Filename: \custom_components\tesira_ttp\select.py                                                                    #
+# Repository: tesira_ttp                                                                                               #
+# Created Date: Thursday, July 9th 2026, 11:38:40 PM                                                                   #
+# Last Modified: Friday, July 10th 2026, 12:10:40 AM                                                                   #
+# Original Author: Darnel Kumar                                                                                        #
+# Author Github: https://github.com/Darnel-K                                                                           #
+#                                                                                                                      #
+# License: GNU Affero General Public License v3.0 only - https://www.gnu.org/licenses/agpl.txt                         #
+# Copyright (c) 2026 Darnel Kumar                                                                                      #
+#                                                                                                                      #
+# This program is free software: you can redistribute it and/or modify                                                 #
+# it under the terms of the GNU Affero General Public License as published                                             #
+# by the Free Software Foundation, either version 3 of the License, or                                                 #
+# (at your option) any later version.                                                                                  #
+#                                                                                                                      #
+# This program is distributed in the hope that it will be useful,                                                      #
+# but WITHOUT ANY WARRANTY; without even the implied warranty of                                                       #
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                                                        #
+# GNU Affero General Public License for more details.                                                                  #
+#                                                                                                                      #
+# You should have received a copy of the GNU Affero General Public License                                             #
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.                                               #
+# #################################################################################################################### #
+from __future__ import annotations
+
+import logging
+import copy
+from typing import Any
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.components.select import SelectEntity
+from homeassistant.helpers import entity_registry as er
+
+from .const import DOMAIN, DICT_KEYS, DEFAULTS
+from .hub import TesiraHub
+
+
+_LOGGER = logging.getLogger(__name__)
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities) -> None:
+    """Set up Tesira select entities for a config entry."""
+
+    hubkey = entry.entry_id
+    hub: TesiraHub = hass.data[DOMAIN][DICT_KEYS["DATA_HUBS"]][hubkey]
+    entities = copy.deepcopy(entry.options.get(DICT_KEYS["ENTITIES"], DEFAULTS["ENTITIES"]))
+    entities_list = []
+    audio_meter_tags_added: set[str | None] = set()
+
+    # Build entities from the dynamic options structure by block type.
+    for entity in entities:
+        if "select" in entity[DICT_KEYS["ENTITY_BLOCK_SUPPORTED_TYPES"]]:
+            match entity[DICT_KEYS["ENTITY_BLOCK_TYPE"]]:
+                case "audio_meter":
+                    instance_tag = entity.get(DICT_KEYS["ENTITY_BLOCK_INSTANCE_TAG"])
+                    if instance_tag in audio_meter_tags_added:
+                        continue
+                    audio_meter_tags_added.add(instance_tag)
+                    entities_list.append(TesiraAudioMeterBlockType(hub=hub, hubkey=hubkey, entity=entity))
+                case _:
+                    _LOGGER.debug(
+                        "Unsupported button block type '%s' for entity: %s",
+                        entity.get(DICT_KEYS["ENTITY_BLOCK_TYPE"]),
+                        entity,
+                    )
+
+
+    # Remove stale button entities no longer present in the current config.
+    entity_registry = er.async_get(hass)
+    expected_ids = {e.unique_id for e in entities_list}
+    for entity_entry in er.async_entries_for_config_entry(entity_registry, entry.entry_id):
+        if entity_entry.domain == "select" and entity_entry.unique_id not in expected_ids:
+            entity_registry.async_remove(entity_entry.entity_id)
+
+    async_add_entities(entities_list, update_before_add=True)
+
+class TesiraAudioMeterBlockType(SelectEntity):
+    """Expose a Tesira audio meter block (Type) as a Home Assistant button entity."""
+
+    def __init__(self, hub: TesiraHub, hubkey: str, entity: dict[str, Any]) -> None:
+        self._hub = hub
+        self._hubkey = hubkey
+        self._entity = entity
+        self._instance_tag = entity.get(DICT_KEYS["ENTITY_BLOCK_INSTANCE_TAG"])
+        self._block_type = entity.get(DICT_KEYS["ENTITY_BLOCK_TYPE"])
+        self._device_id = entity.get(DICT_KEYS["DEVICE_ID"])
+        self._channel = int(entity.get(DICT_KEYS["ENTITY_BLOCK_CHANNEL"]))
+        self._attr_name = f"Tesira Audio Meter Block - Tag:{self._instance_tag} - Attr:Type - Chan:{self._channel} ({self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]})"
+        self._attr_unique_id = f"tesira_ttp_{self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]}_{self._block_type}_{self._instance_tag}_type_{self._channel}".lower()
+        self._attr_available = True
+        self._attr_options = ["PEAK", "RMS"]
+
+    @property
+    def device_info(self):
+        return {DICT_KEYS["ENTITY_DEVICE_IDENTIFIERS"]: {(DOMAIN, self._device_id)}} if self._device_id != "None" else None
+
+    async def async_update(self) -> None:
+        try:
+            # Limits may differ between blocks/channels, so refresh before conversion each cycle.
+            resp = await self._hub.json(f"{self._instance_tag} get type")
+            type = resp["value"]
+            if type is not None:
+                self._current_option = type
+                self._attr_available = True
+            else:
+                raise ValueError(f"Could not parse type from response: {resp!r}")
+        except Exception as e:
+            _LOGGER.debug("Update failed for %s: %s", self._attr_unique_id, e)
+            self._attr_available = False
+
+    async def async_select_option(self, option: str) -> None:
+        try:
+            # Limits may differ between blocks/channels, so refresh before conversion each cycle.
+            await self._hub.json(f"{self._instance_tag} set type {option}")
+        except Exception as e:
+            _LOGGER.debug("Update failed for %s: %s", self._attr_unique_id, e)
+            self._attr_available = False

--- a/custom_components/tesira_ttp/sensor.py
+++ b/custom_components/tesira_ttp/sensor.py
@@ -1,8 +1,8 @@
 # #################################################################################################################### #
-# Filename: \custom_components\tesira_ttp\media_player.py                                                              #
+# Filename: \custom_components\tesira_ttp\sensor.py                                                                    #
 # Repository: tesira_ttp                                                                                               #
-# Created Date: Wednesday, July 8th 2026, 1:46:51 AM                                                                   #
-# Last Modified: Monday, July 13th 2026, 11:58:54 PM                                                                   #
+# Created Date: Thursday, April 16th 2026, 11:44:37 PM                                                                 #
+# Last Modified: Tuesday, July 14th 2026, 12:17:57 AM                                                                  #
 # Original Author: Darnel Kumar                                                                                        #
 # Author Github: https://github.com/Darnel-K                                                                           #
 #                                                                                                                      #
@@ -30,18 +30,19 @@ from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.components.media_player import MediaPlayerEntity
-from homeassistant.components.media_player.const import MediaPlayerEntityFeature, MediaPlayerState
+from homeassistant.components.sensor import SensorEntity, SensorDeviceClass
 from homeassistant.helpers import entity_registry as er
 
 from .const import DOMAIN, DICT_KEYS, DEFAULTS
-from .util import db_to_level, level_to_db, _coerce_bool
 from .hub import TesiraHub
+from .util import _coerce_bool
 
 
 _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities) -> None:
+    """Set up Tesira sensor entities for a config entry."""
+
     hubkey = entry.entry_id
     hub: TesiraHub = hass.data[DOMAIN][DICT_KEYS["DATA_HUBS"]][hubkey]
     # devices = copy.deepcopy(entry.data.get(DICT_KEYS["DEVICES"], DEFAULTS["DEVICES"]))
@@ -50,23 +51,31 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
 
     # Build entities from the dynamic options structure by block type.
     for entity in entities:
-        if "media_player" in entity[DICT_KEYS["ENTITY_BLOCK_SUPPORTED_TYPES"]]:
+        if "sensor" in entity[DICT_KEYS["ENTITY_BLOCK_SUPPORTED_TYPES"]]:
             match entity[DICT_KEYS["ENTITY_BLOCK_TYPE"]]:
-                case "level":
-                    entities_list.append(TesiraLevelBlockLevel(hub=hub, hubkey=hubkey, entity=entity))
+                case "audio_meter":
+                    entities_list.append(TesiraAudioMeterBlockLevel(hub=hub, hubkey=hubkey, entity=entity))
+                case "signal_present_meter":
+                    entities_list.append(TesiraSignalPresentMeterBlockLevel(hub=hub, hubkey=hubkey, entity=entity))
+                case _:
+                    _LOGGER.debug(
+                        "Unsupported switch block type '%s' for entity: %s",
+                        entity.get(DICT_KEYS["ENTITY_BLOCK_TYPE"]),
+                        entity,
+                    )
 
 
-    # Remove stale media_player entities no longer present in the current config.
+    # Remove stale switch entities no longer present in the current config.
     entity_registry = er.async_get(hass)
     expected_ids = {e.unique_id for e in entities_list}
     for entity_entry in er.async_entries_for_config_entry(entity_registry, entry.entry_id):
-        if entity_entry.domain == "media_player" and entity_entry.unique_id not in expected_ids:
+        if entity_entry.domain == "sensor" and entity_entry.unique_id not in expected_ids:
             entity_registry.async_remove(entity_entry.entity_id)
 
     async_add_entities(entities_list, update_before_add=True)
 
-class TesiraLevelBlockLevel(MediaPlayerEntity):
-    """Expose a Tesira level block (Level) as a Home Assistant media player volume entity."""
+class TesiraAudioMeterBlockLevel(SensorEntity):
+    """Expose a Tesira audio meter block (Level) as a Home Assistant switch entity."""
 
     def __init__(self, hub: TesiraHub, hubkey: str, entity: dict[str, Any]) -> None:
         self._hub = hub
@@ -77,19 +86,12 @@ class TesiraLevelBlockLevel(MediaPlayerEntity):
         self._device_id = entity.get(DICT_KEYS["DEVICE_ID"])
         self._channel = int(entity.get(DICT_KEYS["ENTITY_BLOCK_CHANNEL"]))
         self._sub = entity.get(DICT_KEYS["ENTITY_BLOCK_SUBSCRIBE"])
-        self._attr_name = f"Tesira Level Block - Tag:{self._instance_tag} - Attr:Level - Chan:{self._channel} ({self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]})"
+        self._attr_name = f"Tesira Audio Meter Block - Tag:{self._instance_tag} - Attr:Level - Chan:{self._channel} ({self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]})"
         self._attr_unique_id = f"tesira_ttp_{self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]}_{self._block_type}_{self._instance_tag}_level_{self._channel}".lower()
-        self._attr_supported_features = (
-            MediaPlayerEntityFeature.VOLUME_SET
-            | MediaPlayerEntityFeature.VOLUME_STEP
-            | MediaPlayerEntityFeature.VOLUME_MUTE
-        )
-        self._attr_state = MediaPlayerState.IDLE
+        self._attr_device_class = SensorDeviceClass.SOUND_PRESSURE
+        self._attr_native_unit_of_measurement = "dB"
+        self._attr_suggested_display_precision = 2
         self._attr_available = True
-        self._max_db: float = 12.0
-        self._min_db: float = -100.0
-        self._current_level: float | None = None
-        self._muted: bool | None = None
 
         if self._sub:
             # Subscription mode pushes updates from the DSP, so polling is unnecessary.
@@ -98,96 +100,102 @@ class TesiraLevelBlockLevel(MediaPlayerEntity):
             self._attr_should_poll = True
 
     @property
-    def volume_level(self) -> float | None:
-        if self._current_level is None:
-            return None
-        return db_to_level(self._current_level, self._min_db, self._max_db)
-
-    @property
-    def is_volume_muted(self) -> bool | None:
-        return self._muted
-
-    @property
     def device_info(self):
         return {DICT_KEYS["ENTITY_DEVICE_IDENTIFIERS"]: {(DOMAIN, self._device_id)}} if self._device_id != "None" else None
 
-    async def get_block_details(self) -> None:
-        # Pull live min/max dB limits to normalize volume values correctly for this block.
-        resp = await self._hub.json(f"{self._instance_tag} get maxLevel {self._channel}")
-        self._max_db = float(resp.get("value", 12.0))
-        resp = await self._hub.json(f"{self._instance_tag} get minLevel {self._channel}")
-        self._min_db = float(resp.get("value", -100.0))
-
-    def _update_level_from_sub(self, data: dict) -> None:
+    def _update_state_from_sub(self, data: dict) -> None:
         level = data.get("value")
         if level is not None:
-            self._current_level = float(level)
+            self._attr_native_value = level
             self._attr_available = True
-            self._attr_state = MediaPlayerState.IDLE
             self._hass.loop.call_soon_threadsafe(self.async_write_ha_state)
         else:
             _LOGGER.warning("Received subscription update without level value: %s", data)
-
-    def _update_mute_from_sub(self, data: dict) -> None:
-        muted = data.get("value")
-        if muted is not None:
-            self._muted = _coerce_bool(muted)
-            self._hass.loop.call_soon_threadsafe(self.async_write_ha_state)
-        else:
-            _LOGGER.warning("Received subscription update without mute value: %s", data)
 
     async def async_added_to_hass(self) -> None:
         self._hass = self.hass
         if self._sub:
             # Prime state once before starting subscriptions to avoid an empty initial UI state.
             await self.async_update()
-            await self._hub.subscribe(self._instance_tag, "level", self._channel, f"hass_media_player_level_level_{self._instance_tag}_{self._channel}", 100, self._update_level_from_sub)
-            await self._hub.subscribe(self._instance_tag, "mute", self._channel, f"hass_media_player_level_mute_{self._instance_tag}_{self._channel}", 100, self._update_mute_from_sub)
+            await self._hub.subscribe(self._instance_tag, "level", self._channel, f"hass_sensor_audio_meter_level_{self._instance_tag}_{self._channel}", 100, self._update_state_from_sub)
 
     async def async_will_remove_from_hass(self) -> None:
         if self._sub:
-            await self._hub.unsubscribe(f"hass_media_player_level_level_{self._instance_tag}_{self._channel}")
-            await self._hub.unsubscribe(f"hass_media_player_level_mute_{self._instance_tag}_{self._channel}")
+            await self._hub.unsubscribe(f"hass_sensor_audio_meter_level_{self._instance_tag}_{self._channel}")
 
     async def async_update(self) -> None:
         try:
             # Limits may differ between blocks/channels, so refresh before conversion each cycle.
-            await self.get_block_details()
             resp = await self._hub.json(f"{self._instance_tag} get level {self._channel}")
             level = resp["value"]
             if level is not None:
-                self._current_level = float(level)
+                self._attr_native_value = level
                 self._attr_available = True
-                self._attr_state = MediaPlayerState.IDLE
             else:
                 raise ValueError(f"Could not parse level from response: {resp!r}")
-
-            try:
-                resp_m = await self._hub.json(f"{self._instance_tag} get mute {self._channel}")
-                muted = resp_m['value']
-                if muted is not None:
-                    self._muted = _coerce_bool(muted)
-            except Exception:
-                pass
         except Exception as e:
             _LOGGER.debug("Update failed for %s: %s", self._attr_unique_id, e)
             self._attr_available = False
 
-    async def async_set_volume_level(self, volume: float) -> None:
-        db = level_to_db(volume, self._min_db, self._max_db)
-        await self._hub.json(f"{self._instance_tag} set level {self._channel} {db:.3f}")
-        self._current_level = db
+class TesiraSignalPresentMeterBlockLevel(SensorEntity):
+    """Expose a Tesira signal present meter block (Level) as a Home Assistant switch entity."""
 
-    async def async_volume_up(self) -> None:
-        await self._hub.json(f"{self._instance_tag} increment level {self._channel} 0.1")
+    def __init__(self, hub: TesiraHub, hubkey: str, entity: dict[str, Any]) -> None:
+        self._hub = hub
+        self._hubkey = hubkey
+        self._entity = entity
+        self._instance_tag = entity.get(DICT_KEYS["ENTITY_BLOCK_INSTANCE_TAG"])
+        self._block_type = entity.get(DICT_KEYS["ENTITY_BLOCK_TYPE"])
+        self._device_id = entity.get(DICT_KEYS["DEVICE_ID"])
+        self._channel = int(entity.get(DICT_KEYS["ENTITY_BLOCK_CHANNEL"]))
+        self._sub = entity.get(DICT_KEYS["ENTITY_BLOCK_SUBSCRIBE"])
+        self._attr_name = f"Tesira Signal Present Meter Block - Tag:{self._instance_tag} - Attr:Level - Chan:{self._channel} ({self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]})"
+        self._attr_unique_id = f"tesira_ttp_{self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]}_{self._block_type}_{self._instance_tag}_level_{self._channel}".lower()
+        self._attr_device_class = SensorDeviceClass.SOUND_PRESSURE
+        self._attr_native_unit_of_measurement = "dB"
+        self._attr_suggested_display_precision = 2
+        self._attr_available = True
 
-    async def async_volume_down(self) -> None:
-        await self._hub.json(f"{self._instance_tag} increment level {self._channel} -0.1")
-
-    async def async_mute_volume(self, mute: bool) -> None:
-        resp = await self._hub.json(f"{self._instance_tag} set mute {self._channel} {'true' if mute else 'false'}")
-        if "error" in resp:
-            _LOGGER.warning("Mute command returned error for %s: %s", self._attr_unique_id, resp['error'])
+        if self._sub:
+            # Subscription mode pushes updates from the DSP, so polling is unnecessary.
+            self._attr_should_poll = False
         else:
-            self._muted = mute
-            self.async_write_ha_state()
+            self._attr_should_poll = True
+
+    @property
+    def device_info(self):
+        return {DICT_KEYS["ENTITY_DEVICE_IDENTIFIERS"]: {(DOMAIN, self._device_id)}} if self._device_id != "None" else None
+
+    def _update_state_from_sub(self, data: dict) -> None:
+        level = data.get("value")
+        if level is not None:
+            self._attr_native_value = level
+            self._attr_available = True
+            self._hass.loop.call_soon_threadsafe(self.async_write_ha_state)
+        else:
+            _LOGGER.warning("Received subscription update without level value: %s", data)
+
+    async def async_added_to_hass(self) -> None:
+        self._hass = self.hass
+        if self._sub:
+            # Prime state once before starting subscriptions to avoid an empty initial UI state.
+            await self.async_update()
+            await self._hub.subscribe(self._instance_tag, "level", self._channel, f"hass_sensor_signal_present_meter_level_{self._instance_tag}_{self._channel}", 100, self._update_state_from_sub)
+
+    async def async_will_remove_from_hass(self) -> None:
+        if self._sub:
+            await self._hub.unsubscribe(f"hass_sensor_signal_present_meter_level_{self._instance_tag}_{self._channel}")
+
+    async def async_update(self) -> None:
+        try:
+            # Limits may differ between blocks/channels, so refresh before conversion each cycle.
+            resp = await self._hub.json(f"{self._instance_tag} get level {self._channel}")
+            level = resp["value"]
+            if level is not None:
+                self._attr_native_value = level
+                self._attr_available = True
+            else:
+                raise ValueError(f"Could not parse level from response: {resp!r}")
+        except Exception as e:
+            _LOGGER.debug("Update failed for %s: %s", self._attr_unique_id, e)
+            self._attr_available = False

--- a/custom_components/tesira_ttp/switch.py
+++ b/custom_components/tesira_ttp/switch.py
@@ -1,8 +1,8 @@
 # #################################################################################################################### #
 # Filename: \custom_components\tesira_ttp\switch.py                                                                    #
 # Repository: tesira_ttp                                                                                               #
-# Created Date: Thursday, March 19th 2026, 12:56:52 AM                                                                 #
-# Last Modified: Wednesday, July 8th 2026, 1:27:02 AM                                                                  #
+# Created Date: Thursday, April 16th 2026, 11:44:37 PM                                                                 #
+# Last Modified: Tuesday, July 14th 2026, 12:17:57 AM                                                                  #
 # Original Author: Darnel Kumar                                                                                        #
 # Author Github: https://github.com/Darnel-K                                                                           #
 #                                                                                                                      #
@@ -54,21 +54,26 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
         if "switch" in entity[DICT_KEYS["ENTITY_BLOCK_SUPPORTED_TYPES"]]:
             match entity[DICT_KEYS["ENTITY_BLOCK_TYPE"]]:
                 case "logic_state":
-                    entities_list.append(TesiraLogicStateBlock(hub=hub, hubkey=hubkey, entity=entity))
+                    entities_list.append(TesiraLogicStateBlockState(hub=hub, hubkey=hubkey, entity=entity))
                 case "logic_selector":
-                    entities_list.append(TesiraLogicSelectorBlock(hub=hub, hubkey=hubkey, entity=entity))
+                    entities_list.append(TesiraLogicSelectorBlockState(hub=hub, hubkey=hubkey, entity=entity))
                 case "flip_flop":
-                    entities_list.append(TesiraFlipFlopBlock(hub=hub, hubkey=hubkey, entity=entity))
+                    entities_list.append(TesiraFlipFlopBlockState(hub=hub, hubkey=hubkey, entity=entity))
                 case "logic_delay":
-                    entities_list.append(TesiraLogicDelayBlock(hub=hub, hubkey=hubkey, entity=entity))
+                    entities_list.append(TesiraLogicDelayBlockBypass(hub=hub, hubkey=hubkey, entity=entity))
                 case "logic_input":
-                    entities_list.append(TesiraLogicInputBlock(hub=hub, hubkey=hubkey, entity=entity))
+                    entities_list.append(TesiraLogicInputBlockInvert(hub=hub, hubkey=hubkey, entity=entity))
                 case "logic_output":
-                    entities_list.append(TesiraLogicOutputBlock(hub=hub, hubkey=hubkey, entity=entity))
+                    entities_list.append(TesiraLogicOutputBlockInvert(hub=hub, hubkey=hubkey, entity=entity))
                 case "logic_pulse":
                     entities_list.append(TesiraLogicPulseBlockIndefinite(hub=hub, hubkey=hubkey, entity=entity))
                 case "logic_sequence":
                     entities_list.append(TesiraLogicSequenceBlockIndefinite(hub=hub, hubkey=hubkey, entity=entity))
+                case "audio_meter":
+                    entities_list.append(TesiraAudioMeterBlockHoldEnabled(hub=hub, hubkey=hubkey, entity=entity))
+                    entities_list.append(TesiraAudioMeterBlockIndefiniteHold(hub=hub, hubkey=hubkey, entity=entity))
+                case "signal_present_meter":
+                    entities_list.append(TesiraSignalPresentMeterBlockInvert(hub=hub, hubkey=hubkey, entity=entity))
                 case _:
                     _LOGGER.debug(
                         "Unsupported switch block type '%s' for entity: %s",
@@ -86,8 +91,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
 
     async_add_entities(entities_list, update_before_add=True)
 
-class TesiraLogicStateBlock(SwitchEntity):
-    """Expose a Tesira logic state block as a Home Assistant switch entity."""
+class TesiraLogicStateBlockState(SwitchEntity):
+    """Expose a Tesira logic state block (State) as a Home Assistant switch entity."""
 
     def __init__(self, hub: TesiraHub, hubkey: str, entity: dict[str, Any]) -> None:
         self._hub = hub
@@ -127,11 +132,11 @@ class TesiraLogicStateBlock(SwitchEntity):
         if self._sub:
             # Prime state once before starting subscriptions to avoid an empty initial UI state.
             await self.async_update()
-            await self._hub.subscribe(self._instance_tag, "state", self._channel, f"hass_switch_logic_state_{self._instance_tag}_{self._channel}", 100, self._update_state_from_sub)
+            await self._hub.subscribe(self._instance_tag, "state", self._channel, f"hass_switch_logic_state_state_{self._instance_tag}_{self._channel}", 100, self._update_state_from_sub)
 
     async def async_will_remove_from_hass(self) -> None:
         if self._sub:
-            await self._hub.unsubscribe(f"hass_switch_logic_state_{self._instance_tag}_{self._channel}")
+            await self._hub.unsubscribe(f"hass_switch_logic_state_state_{self._instance_tag}_{self._channel}")
 
     async def async_update(self) -> None:
         try:
@@ -170,8 +175,8 @@ class TesiraLogicStateBlock(SwitchEntity):
         except Exception as e:
             _LOGGER.debug("Toggle failed for %s: %s", self._attr_unique_id, e)
 
-class TesiraFlipFlopBlock(SwitchEntity):
-    """Expose a Tesira flip flop block as a Home Assistant switch entity."""
+class TesiraFlipFlopBlockState(SwitchEntity):
+    """Expose a Tesira flip flop block (State) as a Home Assistant switch entity."""
 
     def __init__(self, hub: TesiraHub, hubkey: str, entity: dict[str, Any]) -> None:
         self._hub = hub
@@ -211,11 +216,11 @@ class TesiraFlipFlopBlock(SwitchEntity):
         if self._sub:
             # Prime state once before starting subscriptions to avoid an empty initial UI state.
             await self.async_update()
-            await self._hub.subscribe(self._instance_tag, "state", self._channel, f"hass_switch_flip_flop_{self._instance_tag}_{self._channel}", 100, self._update_state_from_sub)
+            await self._hub.subscribe(self._instance_tag, "state", self._channel, f"hass_switch_flip_flop_state_{self._instance_tag}_{self._channel}", 100, self._update_state_from_sub)
 
     async def async_will_remove_from_hass(self) -> None:
         if self._sub:
-            await self._hub.unsubscribe(f"hass_switch_flip_flop_{self._instance_tag}_{self._channel}")
+            await self._hub.unsubscribe(f"hass_switch_flip_flop_state_{self._instance_tag}_{self._channel}")
 
     async def async_update(self) -> None:
         try:
@@ -254,8 +259,8 @@ class TesiraFlipFlopBlock(SwitchEntity):
         except Exception as e:
             _LOGGER.debug("Toggle failed for %s: %s", self._attr_unique_id, e)
 
-class TesiraLogicDelayBlock(SwitchEntity):
-    """Expose a Tesira logic delay block as a Home Assistant switch entity."""
+class TesiraLogicDelayBlockBypass(SwitchEntity):
+    """Expose a Tesira logic delay block (Bypass) as a Home Assistant switch entity."""
 
     def __init__(self, hub: TesiraHub, hubkey: str, entity: dict[str, Any]) -> None:
         self._hub = hub
@@ -311,8 +316,8 @@ class TesiraLogicDelayBlock(SwitchEntity):
         except Exception as e:
             _LOGGER.debug("Toggle failed for %s: %s", self._attr_unique_id, e)
 
-class TesiraLogicInputBlock(SwitchEntity):
-    """Expose a Tesira logic input block as a Home Assistant switch entity."""
+class TesiraLogicInputBlockInvert(SwitchEntity):
+    """Expose a Tesira logic input block (Invert) as a Home Assistant switch entity."""
 
     def __init__(self, hub: TesiraHub, hubkey: str, entity: dict[str, Any]) -> None:
         self._hub = hub
@@ -368,8 +373,8 @@ class TesiraLogicInputBlock(SwitchEntity):
         except Exception as e:
             _LOGGER.debug("Toggle failed for %s: %s", self._attr_unique_id, e)
 
-class TesiraLogicOutputBlock(SwitchEntity):
-    """Expose a Tesira logic output block as a Home Assistant switch entity."""
+class TesiraLogicOutputBlockInvert(SwitchEntity):
+    """Expose a Tesira logic output block (Invert) as a Home Assistant switch entity."""
 
     def __init__(self, hub: TesiraHub, hubkey: str, entity: dict[str, Any]) -> None:
         self._hub = hub
@@ -425,8 +430,8 @@ class TesiraLogicOutputBlock(SwitchEntity):
         except Exception as e:
             _LOGGER.debug("Toggle failed for %s: %s", self._attr_unique_id, e)
 
-class TesiraLogicSelectorBlock(SwitchEntity):
-    """Expose a Tesira logic selector block as a Home Assistant switch entity."""
+class TesiraLogicSelectorBlockState(SwitchEntity):
+    """Expose a Tesira logic selector block (State) as a Home Assistant switch entity."""
 
     def __init__(self, hub: TesiraHub, hubkey: str, entity: dict[str, Any]) -> None:
         self._hub = hub
@@ -466,11 +471,11 @@ class TesiraLogicSelectorBlock(SwitchEntity):
         if self._sub:
             # Prime state once before starting subscriptions to avoid an empty initial UI state.
             await self.async_update()
-            await self._hub.subscribe(self._instance_tag, "state", self._channel, f"hass_switch_logic_selector_{self._instance_tag}_{self._channel}", 100, self._update_state_from_sub)
+            await self._hub.subscribe(self._instance_tag, "state", self._channel, f"hass_switch_logic_selector_state_{self._instance_tag}_{self._channel}", 100, self._update_state_from_sub)
 
     async def async_will_remove_from_hass(self) -> None:
         if self._sub:
-            await self._hub.unsubscribe(f"hass_switch_logic_selector_{self._instance_tag}_{self._channel}")
+            await self._hub.unsubscribe(f"hass_switch_logic_selector_state_{self._instance_tag}_{self._channel}")
 
     async def async_update(self) -> None:
         try:
@@ -619,6 +624,177 @@ class TesiraLogicSequenceBlockIndefinite(SwitchEntity):
     async def async_toggle(self) -> None:
         try:
             await self._hub.json(f"{self._instance_tag} toggle indefinite {self._channel}")
+            await self.async_update()  # Refresh state after toggle since we don't know the resulting state in advance.
+        except Exception as e:
+            _LOGGER.debug("Toggle failed for %s: %s", self._attr_unique_id, e)
+
+class TesiraAudioMeterBlockHoldEnabled(SwitchEntity):
+    """Expose a Tesira audio meter block (Hold Enabled) as a Home Assistant switch entity."""
+
+    def __init__(self, hub: TesiraHub, hubkey: str, entity: dict[str, Any]) -> None:
+        self._hub = hub
+        self._hubkey = hubkey
+        self._entity = entity
+        self._instance_tag = entity.get(DICT_KEYS["ENTITY_BLOCK_INSTANCE_TAG"])
+        self._block_type = entity.get(DICT_KEYS["ENTITY_BLOCK_TYPE"])
+        self._device_id = entity.get(DICT_KEYS["DEVICE_ID"])
+        self._channel = int(entity.get(DICT_KEYS["ENTITY_BLOCK_CHANNEL"]))
+        self._attr_name = f"Tesira Audio Meter Block - Tag:{self._instance_tag} - Attr:HoldEnabled - Chan:{self._channel} ({self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]})"
+        self._attr_unique_id = f"tesira_ttp_{self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]}_{self._block_type}_{self._instance_tag}_holdenabled_{self._channel}".lower()
+        self._attr_is_on: bool = False
+        self._attr_available = True
+
+    @property
+    def device_info(self):
+        return {DICT_KEYS["ENTITY_DEVICE_IDENTIFIERS"]: {(DOMAIN, self._device_id)}} if self._device_id != "None" else None
+
+    async def async_update(self) -> None:
+        try:
+            # Limits may differ between blocks/channels, so refresh before conversion each cycle.
+            resp = await self._hub.json(f"{self._instance_tag} get holdEnabled {self._channel}")
+            hold_enabled = resp["value"]
+            if hold_enabled is not None:
+                self._attr_is_on = _coerce_bool(hold_enabled)
+                self._attr_available = True
+            else:
+                raise ValueError(f"Could not parse hold enabled state from response: {resp!r}")
+        except Exception as e:
+            _LOGGER.debug("Update failed for %s: %s", self._attr_unique_id, e)
+            self._attr_available = False
+
+    async def async_turn_on(self) -> None:
+        try:
+            await self._hub.json(f"{self._instance_tag} set holdEnabled {self._channel} true")
+            self._attr_is_on = True
+            self.async_write_ha_state()
+        except Exception as e:
+            _LOGGER.debug("Turn on failed for %s: %s", self._attr_unique_id, e)
+
+    async def async_turn_off(self) -> None:
+        try:
+            await self._hub.json(f"{self._instance_tag} set holdEnabled {self._channel} false")
+            self._attr_is_on = False
+            self.async_write_ha_state()
+        except Exception as e:
+            _LOGGER.debug("Turn off failed for %s: %s", self._attr_unique_id, e)
+
+    async def async_toggle(self) -> None:
+        try:
+            await self._hub.json(f"{self._instance_tag} toggle holdEnabled {self._channel}")
+            await self.async_update()
+        except Exception as e:
+            _LOGGER.debug("Toggle failed for %s: %s", self._attr_unique_id, e)
+
+class TesiraAudioMeterBlockIndefiniteHold(SwitchEntity):
+    """Expose a Tesira audio meter block (Indefinite Hold) as a Home Assistant switch entity."""
+
+    def __init__(self, hub: TesiraHub, hubkey: str, entity: dict[str, Any]) -> None:
+        self._hub = hub
+        self._hubkey = hubkey
+        self._entity = entity
+        self._instance_tag = entity.get(DICT_KEYS["ENTITY_BLOCK_INSTANCE_TAG"])
+        self._block_type = entity.get(DICT_KEYS["ENTITY_BLOCK_TYPE"])
+        self._device_id = entity.get(DICT_KEYS["DEVICE_ID"])
+        self._channel = int(entity.get(DICT_KEYS["ENTITY_BLOCK_CHANNEL"]))
+        self._attr_name = f"Tesira Audio Meter Block - Tag:{self._instance_tag} - Attr:IndefiniteHold - Chan:{self._channel} ({self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]})"
+        self._attr_unique_id = f"tesira_ttp_{self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]}_{self._block_type}_{self._instance_tag}_indefinitehold_{self._channel}".lower()
+        self._attr_is_on: bool = False
+        self._attr_available = True
+
+    @property
+    def device_info(self):
+        return {DICT_KEYS["ENTITY_DEVICE_IDENTIFIERS"]: {(DOMAIN, self._device_id)}} if self._device_id != "None" else None
+
+    async def async_update(self) -> None:
+        try:
+            # Limits may differ between blocks/channels, so refresh before conversion each cycle.
+            resp = await self._hub.json(f"{self._instance_tag} get indefiniteHold {self._channel}")
+            hold_enabled = resp["value"]
+            if hold_enabled is not None:
+                self._attr_is_on = _coerce_bool(hold_enabled)
+                self._attr_available = True
+            else:
+                raise ValueError(f"Could not parse indefinite hold state from response: {resp!r}")
+        except Exception as e:
+            _LOGGER.debug("Update failed for %s: %s", self._attr_unique_id, e)
+            self._attr_available = False
+
+    async def async_turn_on(self) -> None:
+        try:
+            await self._hub.json(f"{self._instance_tag} set indefiniteHold {self._channel} true")
+            self._attr_is_on = True
+            self.async_write_ha_state()
+        except Exception as e:
+            _LOGGER.debug("Turn on failed for %s: %s", self._attr_unique_id, e)
+
+    async def async_turn_off(self) -> None:
+        try:
+            await self._hub.json(f"{self._instance_tag} set indefiniteHold {self._channel} false")
+            self._attr_is_on = False
+            self.async_write_ha_state()
+        except Exception as e:
+            _LOGGER.debug("Turn off failed for %s: %s", self._attr_unique_id, e)
+
+    async def async_toggle(self) -> None:
+        try:
+            await self._hub.json(f"{self._instance_tag} toggle indefiniteHold {self._channel}")
+            await self.async_update()
+        except Exception as e:
+            _LOGGER.debug("Toggle failed for %s: %s", self._attr_unique_id, e)
+
+class TesiraSignalPresentMeterBlockInvert(SwitchEntity):
+    """Expose a Tesira signal present meter block (Invert) as a Home Assistant switch entity."""
+
+    def __init__(self, hub: TesiraHub, hubkey: str, entity: dict[str, Any]) -> None:
+        self._hub = hub
+        self._hubkey = hubkey
+        self._entity = entity
+        self._instance_tag = entity.get(DICT_KEYS["ENTITY_BLOCK_INSTANCE_TAG"])
+        self._block_type = entity.get(DICT_KEYS["ENTITY_BLOCK_TYPE"])
+        self._device_id = entity.get(DICT_KEYS["DEVICE_ID"])
+        self._channel = int(entity.get(DICT_KEYS["ENTITY_BLOCK_CHANNEL"]))
+        self._attr_name = f"Tesira Signal Present Meter Block - Tag:{self._instance_tag} - Attr:Invert - Chan:{self._channel} ({self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]})"
+        self._attr_unique_id = f"tesira_ttp_{self._hubkey[:10] if self._device_id == "None" else self._device_id[:10]}_{self._block_type}_{self._instance_tag}_invert_{self._channel}".lower()
+        self._attr_is_on: bool = False
+        self._attr_available = True
+
+    @property
+    def device_info(self):
+        return {DICT_KEYS["ENTITY_DEVICE_IDENTIFIERS"]: {(DOMAIN, self._device_id)}} if self._device_id != "None" else None
+
+    async def async_update(self) -> None:
+        try:
+            # Limits may differ between blocks/channels, so refresh before conversion each cycle.
+            resp = await self._hub.json(f"{self._instance_tag} get invert {self._channel}")
+            invert = resp["value"]
+            if invert is not None:
+                self._attr_is_on = _coerce_bool(invert)
+                self._attr_available = True
+            else:
+                raise ValueError(f"Could not parse invert state from response: {resp!r}")
+        except Exception as e:
+            _LOGGER.debug("Update failed for %s: %s", self._attr_unique_id, e)
+            self._attr_available = False
+
+    async def async_turn_on(self) -> None:
+        try:
+            await self._hub.json(f"{self._instance_tag} set invert {self._channel} true")
+            self._attr_is_on = True
+            self.async_write_ha_state()
+        except Exception as e:
+            _LOGGER.debug("Turn on failed for %s: %s", self._attr_unique_id, e)
+
+    async def async_turn_off(self) -> None:
+        try:
+            await self._hub.json(f"{self._instance_tag} set invert {self._channel} false")
+            self._attr_is_on = False
+            self.async_write_ha_state()
+        except Exception as e:
+            _LOGGER.debug("Turn off failed for %s: %s", self._attr_unique_id, e)
+
+    async def async_toggle(self) -> None:
+        try:
+            await self._hub.json(f"{self._instance_tag} toggle invert {self._channel}")
             await self.async_update()  # Refresh state after toggle since we don't know the resulting state in advance.
         except Exception as e:
             _LOGGER.debug("Toggle failed for %s: %s", self._attr_unique_id, e)

--- a/custom_components/tesira_ttp/tesira_client/__init__.py
+++ b/custom_components/tesira_ttp/tesira_client/__init__.py
@@ -1,0 +1,27 @@
+# #################################################################################################################### #
+# Filename: \custom_components\tesira_ttp\tesira_client\__init__.py                                                    #
+# Repository: tesira_ttp                                                                                               #
+# Created Date: Friday, July 10th 2026, 1:05:48 AM                                                                     #
+# Last Modified: Friday, July 10th 2026, 11:38:31 PM                                                                   #
+# Original Author: Darnel Kumar                                                                                        #
+# Author Github: https://github.com/Darnel-K                                                                           #
+#                                                                                                                      #
+# License: GNU Affero General Public License v3.0 only - https://www.gnu.org/licenses/agpl.txt                         #
+# Copyright (c) 2026 Darnel Kumar                                                                                      #
+#                                                                                                                      #
+# This program is free software: you can redistribute it and/or modify                                                 #
+# it under the terms of the GNU Affero General Public License as published                                             #
+# by the Free Software Foundation, either version 3 of the License, or                                                 #
+# (at your option) any later version.                                                                                  #
+#                                                                                                                      #
+# This program is distributed in the hope that it will be useful,                                                      #
+# but WITHOUT ANY WARRANTY; without even the implied warranty of                                                       #
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                                                        #
+# GNU Affero General Public License for more details.                                                                  #
+#                                                                                                                      #
+# You should have received a copy of the GNU Affero General Public License                                             #
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.                                               #
+# #################################################################################################################### #
+"""Tesira client package exports."""
+
+from .client import TesiraClient

--- a/custom_components/tesira_ttp/tesira_client/cli.py
+++ b/custom_components/tesira_ttp/tesira_client/cli.py
@@ -1,8 +1,8 @@
 # #################################################################################################################### #
-# Filename: \custom_components\tesira_ttp\tesira_cli.py                                                                #
+# Filename: \custom_components\tesira_ttp\tesira_client\cli.py                                                         #
 # Repository: tesira_ttp                                                                                               #
-# Created Date: Thursday, March 19th 2026, 12:56:52 AM                                                                 #
-# Last Modified: Thursday, March 26th 2026, 12:26:02 AM                                                                #
+# Created Date: Friday, July 10th 2026, 1:05:48 AM                                                                     #
+# Last Modified: Friday, July 10th 2026, 11:38:26 PM                                                                   #
 # Original Author: Darnel Kumar                                                                                        #
 # Author Github: https://github.com/Darnel-K                                                                           #
 #                                                                                                                      #
@@ -23,16 +23,19 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.                                               #
 # #################################################################################################################### #
 #!/usr/bin/env python3
-"""
-Tesira Interactive CLI using prompt_toolkit (Windows/Linux/Mac Compatible)
-"""
+"""Tesira Interactive CLI using prompt_toolkit (Windows/Linux/Mac Compatible)."""
 
-import asyncio
 import argparse
+import asyncio
+
 from prompt_toolkit import PromptSession
 from prompt_toolkit.patch_stdout import patch_stdout
 
-from tesira_client import TesiraClient
+try:
+    from .client import TesiraClient
+except ImportError:
+    # Support direct execution: python .\custom_components\tesira_ttp\tesira_client\cli.py
+    from client import TesiraClient
 
 
 BANNER = r"""

--- a/custom_components/tesira_ttp/tesira_client/client.py
+++ b/custom_components/tesira_ttp/tesira_client/client.py
@@ -1,8 +1,8 @@
 # #################################################################################################################### #
-# Filename: \custom_components\tesira_ttp\tesira_client.py                                                             #
+# Filename: \custom_components\tesira_ttp\tesira_client\client.py                                                      #
 # Repository: tesira_ttp                                                                                               #
-# Created Date: Thursday, March 19th 2026, 12:56:52 AM                                                                 #
-# Last Modified: Monday, April 13th 2026, 12:11:16 AM                                                                  #
+# Created Date: Friday, July 10th 2026, 1:05:48 AM                                                                     #
+# Last Modified: Friday, July 10th 2026, 11:38:20 PM                                                                   #
 # Original Author: Darnel Kumar                                                                                        #
 # Author Github: https://github.com/Darnel-K                                                                           #
 #                                                                                                                      #
@@ -100,6 +100,7 @@ async def _get_telnetlib3():
 
     return _TELNETLIB3_MODULE
 
+
 # Tesira client (SSH + Telnet).
 class TesiraClient:
     """Tesira transport client supporting SSH and Telnet."""
@@ -115,12 +116,10 @@ class TesiraClient:
         port: int = None,
         proto: str = "ssh",
         known_hosts=None,
-
         heartbeat_interval: float = 10.0,
         heartbeat_failure_threshold: int = 3,
         heartbeat_jitter: float = 1.5,
-
-        safe_mode=False
+        safe_mode=False,
     ):
         # Validate protocol and apply default ports.
         proto = proto.lower().strip()
@@ -149,11 +148,11 @@ class TesiraClient:
         self._telnet_reader_future = None
 
         # Internal connection objects
-        self._conn = None        # SSH connection OR sentinel True for telnet
-        self._chan = None        # SSH channel
-        self._session = None     # Session handler
-        self._reader = None      # Telnet reader
-        self._writer = None      # Telnet writer
+        self._conn = None  # SSH connection OR sentinel True for telnet
+        self._chan = None  # SSH channel
+        self._session = None  # Session handler
+        self._reader = None  # Telnet reader
+        self._writer = None  # Telnet writer
 
         self._lock = asyncio.Lock()
 
@@ -173,6 +172,7 @@ class TesiraClient:
         self._subscriptions = {}
         self._event_callback = None
         self._ssh_session_cls = None
+
     # Telnet session internals.
     class _TelnetSession:
         def __init__(self, parent):
@@ -251,6 +251,7 @@ class TesiraClient:
             _LOGGER.debug("[TELNET] Reader task cancelled")
         except Exception as e:
             _LOGGER.error("[TELNET] Reader task crashed: %s", e)
+
     # Connect via SSH or Telnet with retry/backoff.
     async def connect(self, max_retries=5):
         if self._conn:
@@ -262,14 +263,14 @@ class TesiraClient:
             backoff = min(1 * (2 ** (attempt - 1)), 20)
 
             try:
-                _LOGGER.debug("[NET] Connecting via %s to %s:%s",
-                            self.proto.upper(), self.host, self.port)
+                _LOGGER.debug("[NET] Connecting via %s to %s:%s", self.proto.upper(), self.host, self.port)
 
                 # Open SSH transport.
                 if self.proto == "ssh":
                     asyncssh = await _get_asyncssh()
 
                     if self._ssh_session_cls is None:
+
                         class _RuntimeSSHSession(asyncssh.SSHClientSession, TesiraClient._SSHSessionBase):
                             def __init__(self, parent):
                                 asyncssh.SSHClientSession.__init__(self)
@@ -307,7 +308,7 @@ class TesiraClient:
                     self._reader, self._writer = await telnetlib3.open_connection(
                         self.host,
                         self.port,
-                        shell=None
+                        shell=None,
                     )
 
                     self._session = TesiraClient._TelnetSession(self)
@@ -342,6 +343,7 @@ class TesiraClient:
                     _LOGGER.error(f"[NET] Maximum connection attempts reached: {e}")
                     raise ConnectionError(f"Maximum connection attempts reached: {e}")
                 await asyncio.sleep(backoff)
+
     # Close active transport and stop heartbeat.
     async def disconnect(self):
         if self._telnet_reader_future:
@@ -353,13 +355,13 @@ class TesiraClient:
                 try:
                     self._conn.close()
                     await self._conn.wait_closed()
-                except:
+                except Exception:
                     pass
         else:
             if self._writer:
                 try:
                     self._writer.close()
-                except:
+                except Exception:
                     pass
 
         self._conn = None
@@ -367,12 +369,14 @@ class TesiraClient:
         if self._heartbeat_task:
             self._heartbeat_task.cancel()
             self._heartbeat_task = None
+
     # Write raw text to the active transport.
     async def _send(self, text: str):
         if self.proto == "ssh":
             self._chan.write(text)
         else:
             self._writer.write(text)
+
     # Run a command and parse the final +OK/-ERR response token.
     async def command(self, cmd: str, timeout: float = 5.0):
         async with self._lock:
@@ -392,34 +396,23 @@ class TesiraClient:
             try:
                 await asyncio.wait_for(self._session.complete.wait(), timeout)
             except asyncio.TimeoutError:
-                raise self.TimeoutError(
-                    "Timeout waiting for +OK or -ERR",
-                    raw=self._session.buffer,
-                    cmd=cmd,
-                )
+                raise self.TimeoutError("Timeout waiting for +OK or -ERR", raw=self._session.buffer, cmd=cmd)
 
             # Add a short tail wait so fragmented payloads can finish arriving.
-            IDLE_GRACE = 0.15  # seconds; suitable for multi-kB responses
+            idle_grace = 0.15  # seconds; suitable for multi-kB responses
 
             while True:
-                await asyncio.sleep(IDLE_GRACE)
+                await asyncio.sleep(idle_grace)
                 now = asyncio.get_event_loop().time()
-                if now - self._session._last_rx >= IDLE_GRACE:
+                if now - self._session._last_rx >= idle_grace:
                     break
             raw = self._session.buffer.strip()
             lines = [l.strip() for l in raw.splitlines()]
 
-            final = next(
-                (l for l in lines if l.startswith("+OK") or l.startswith("-ERR")),
-                None,
-            )
+            final = next((l for l in lines if l.startswith("+OK") or l.startswith("-ERR")), None)
 
             if not final:
-                raise self.CommandError(
-                    "No +OK/-ERR returned",
-                    raw=raw,
-                    cmd=cmd,
-                )
+                raise self.CommandError("No +OK/-ERR returned", raw=raw, cmd=cmd)
 
             if final.startswith("-ERR"):
                 if self.safe_mode:
@@ -427,6 +420,7 @@ class TesiraClient:
                 raise self.CommandError(final, raw=raw, cmd=cmd)
 
             return final
+
     # Parse a Tesira +OK payload into JSON-like data.
     async def json(self, cmd: str):
         raw = await self.command(cmd)
@@ -454,22 +448,17 @@ class TesiraClient:
             payload = "{" + payload + "}"
 
         # Quote unquoted enum literals
-        payload = re.sub(
-            r':([A-Z_][A-Z0-9_]*)\b(?!")',
-            r':"\1"',
-            payload
-        )
+        payload = re.sub(r':([A-Z_][A-Z0-9_]*)\b(?!")', r':"\1"', payload)
 
         try:
             return json.loads(payload)
         except Exception as e:
             raise self.JSONParseError(f"JSON parsing failed: {e}", raw=payload, cmd=cmd)
+
     # Periodic health check that disconnects after repeated failures.
     async def _heartbeat_loop(self):
         while True:
-            interval = self._heartbeat_interval + random.uniform(
-                -self._heartbeat_jitter, self._heartbeat_jitter
-            )
+            interval = self._heartbeat_interval + random.uniform(-self._heartbeat_jitter, self._heartbeat_jitter)
             interval = max(1, interval)
 
             await asyncio.sleep(interval)
@@ -479,11 +468,11 @@ class TesiraClient:
                 self._heartbeat_failures = 0
             except Exception as e:
                 self._heartbeat_failures += 1
-                _LOGGER.warning("Heartbeat failure %s: %s",
-                                self._heartbeat_failures, e)
+                _LOGGER.warning("Heartbeat failure %s: %s", self._heartbeat_failures, e)
 
                 if self._heartbeat_failures >= self._heartbeat_failure_threshold:
                     await self.disconnect()
+
     # Subscription helpers.
     async def subscribe(self, object_type, attribute, index, token, interval_ms, callback):
         cmd = f"{object_type} subscribe {attribute} {index} {token} {interval_ms}"
@@ -527,7 +516,7 @@ class TesiraClient:
         for key, value in pairs:
             try:
                 data[key] = float(value) if "." in value else int(value)
-            except:
+            except Exception:
                 data[key] = value
 
         token = data.get("publishToken")
@@ -556,6 +545,7 @@ class TesiraClient:
                     cb(data)
             except Exception as e:
                 _LOGGER.error("[EVENT ERROR global] %s", e)
+
     # Helper methods.
     async def ping(self):
         start = time.perf_counter()
@@ -587,6 +577,7 @@ class TesiraClient:
     # Custom exception types.
     class CommandError(Exception):
         """Represents a Tesira TTP -ERR response."""
+
         def __init__(self, message, raw=None, cmd=None):
             super().__init__(message)
             self.message = message


### PR DESCRIPTION
… subscription hardening and client package refactor (#66)

* Add audio meter entity support

Register the new select platform and add audio meter block support across the integration. This introduces sensor and select entities for meter level and type, plus switch and number entities for hold-related controls, and updates the block schema so audio meter blocks can expose these entity types.

* Disambiguate Tesira subscription IDs

Updated entity subscription/unsubscription identifiers across binary sensor, sensor, switch, and media player platforms to use clearer, domain-specific names and include the tracked attribute (e.g., state/level/mute). This reduces key collisions between subscriptions on the same instance/channel and keeps subscription routing consistent.

* fix(cli): isolate Tesira CLI/client into dedicated package

- Fixes Windows import-shadowing failures when running the standalone CLI from within the Home Assistant integration tree.

- Moves CLI and transport client into custom_components/tesira_ttp/tesira_client to avoid collisions with Home Assistant platform module names.

- Replaces flat files with a package layout: __init__.py, client.py, and cli.py.

- Preserves existing Home Assistant imports by re-exporting TesiraClient from tesira_client/__init__.py, so from .tesira_client import TesiraClient continues to work.

- Eliminates module/package ambiguity by removing the old top-level tesira_client.py and tesira_cli.py files.

- Keeps behavior stable for integration code paths while providing a clean standalone CLI entrypoint at custom_components/tesira_ttp/tesira_client/cli.py.

* fix(subscriptions): prevent token collisions across Tesira entities

- Fixes a routing bug where subscription tokens were not consistently unique across entity domains and attributes, which could cause updates to be delivered to the wrong callback path.

- Makes subscription IDs explicit and attribute-scoped by encoding both entity intent and tracked attribute in the token value (for example: state, level, mute).

- Updates both subscribe and unsubscribe token construction so teardown always targets the exact live subscription that was created.

- Applies the token disambiguation consistently across binary_sensor, sensor, switch, and media_player platforms to keep behavior uniform.

- Reduces cross-entity key collisions for shared instance_tag/channel combinations, improving event routing stability during concurrent subscriptions.

- Preserves functional behavior of entities while hardening subscription lifecycle correctness and reducing intermittent state desynchronization risk.

* fix(cli): isolate Tesira CLI/client into dedicated package

- Fixes Windows import-shadowing failures when running the standalone CLI from within the Home Assistant integration tree.

- Moves CLI and transport client into custom_components/tesira_ttp/tesira_client to avoid collisions with Home Assistant platform module names.

- Replaces flat files with a package layout: __init__.py, client.py, and cli.py.

- Preserves existing Home Assistant imports by re-exporting TesiraClient from tesira_client/__init__.py, so from .tesira_client import TesiraClient continues to work.

- Eliminates module/package ambiguity by removing the old top-level tesira_client.py and tesira_cli.py files.

- Keeps behavior stable for integration code paths while providing a clean standalone CLI entrypoint at custom_components/tesira_ttp/tesira_client/cli.py.

* Add AGPL headers to Tesira client modules

Add standardized file headers to `tesira_client/__init__.py`, `tesira_client/cli.py`, and `tesira_client/client.py` with author metadata, repository details, copyright, and GNU AGPL v3 licensing terms to ensure consistent attribution and licensing notices.

* Enable sensor platform and level subscriptions

Adds `Platform.SENSOR` to the integration platform list so sensor entities are loaded. It also includes `ENTITY_BLOCK_SUBSCRIBE` in the level block schema fields, allowing level-based entities to opt into subscription behavior.

* feat(signal_present_meter): add full Home Assistant entity support across sensor, binary_sensor, switch, and number platforms

- Add end-to-end `signal_present_meter` block support to the integration’s block schema and entity factory routing so the block can be configured and instantiated like existing meter-capable block types.
- Extend block metadata in constants:
  - Add a new `signal_present_meter` entry to `BLOCK_SCHEMA_DATA`.
  - Define label and supported entity domains as: `switch`, `number`, `sensor`, and `binary_sensor`.
  - Add field support for `device_id`, `instance_tag`, `channel`, `min_value`, `max_value`, and `subscribe`.
  - Introduce field option bounds for integer min/max inputs to constrain configuration to valid operational ranges.
- Implement new binary sensor entities for signal-presence state exposure:
  - `LogicState` binary sensor:
    - Reads DSP state via `get logicstate <channel>`.
    - Coerces Tesira response values into Home Assistant boolean state.
    - Marks entity unavailable on parsing/communication failures.
  - `Present` binary sensor:
    - Supports both polling and subscription-driven updates.
    - Uses initial state priming on entity add when subscription mode is enabled.
    - Registers and unregisters subscription callbacks cleanly on add/remove lifecycle events.
    - Updates Home Assistant state thread-safely on asynchronous callback updates.
- Implement new sensor entity for signal level telemetry:
  - `Level` sensor:
    - Reads DSP value via `get level <channel>`.
    - Supports optional subscription updates for near-real-time state changes.
    - Sets sound-pressure device semantics (`dB`, display precision) for consistent HA UX.
    - Handles lifecycle-safe subscribe/unsubscribe and availability fallback on failures.
- Implement new switch entity for invert control:
  - `Invert` switch:
    - Reads state via `get invert <channel>`.
    - Supports `turn_on`, `turn_off`, and `toggle` commands with immediate UI state refresh.
    - Uses robust boolean coercion and availability handling.
- Implement new number entities for timing/threshold controls:
  - `OffDelay` number:
    - Gets/sets `offDelay` per channel.
    - Uses duration semantics with millisecond unit and boxed input mode.
    - Applies runtime clamping using configured min/max safety limits.
  - `OnDelay` number:
    - Gets/sets `onDelay` per channel.
    - Mirrors duration semantics and bounds behavior used by `OffDelay`.
  - `Threshold` number:
    - Gets/sets `threshold` per channel.
    - Enforces valid threshold bounds at entity construction time.
- Wire platform setup dispatchers to instantiate the new `signal_present_meter` entities:
  - Binary sensor platform now creates both logic and presence entities.
  - Sensor platform now creates level entity.
  - Switch platform now creates invert entity.
  - Number platform now creates off-delay, on-delay, and threshold entities.
- Preserve integration consistency and maintainability:
  - Follow existing naming and unique ID conventions for entity identity stability.
  - Reuse shared bool coercion and hub JSON command pathways for consistent parsing and transport behavior.
  - Keep subscription token naming explicit and domain-specific to reduce collision risk.
- Outcome:
  - `signal_present_meter` blocks are now first-class citizens in the integration.
  - Users gain full monitoring and control surface (presence, logic state, level, invert, delays, threshold) directly in Home Assistant.
  - Subscription-capable entities reduce polling overhead while improving state freshness.

* Rename entity classes for clarity

Rename block entity classes across binary_sensor, media_player, number, and switch platforms to include the specific property they expose (e.g. TesiraLogicMeterBlock → TesiraLogicMeterBlockState, TesiraLogicDelayBlockOn → TesiraLogicDelayBlockOnDelay). Also improve log/error messages to reference the specific value type rather than generic 'state'. Bump version to 0.15.3.

[Closes #50}
Ref #39